### PR TITLE
tag-autocomplete-fixes

### DIFF
--- a/curiefense/ui/src/components/GitHistory.vue
+++ b/curiefense/ui/src/components/GitHistory.vue
@@ -97,7 +97,7 @@ export default {
 
   methods: {
     restoreVersion(commit) {
-      this.$emit('restoreVersion', commit)
+      this.$emit('restore-version', commit)
     },
 
     mouseLeave() {

--- a/curiefense/ui/src/components/TagAutocompleteInput.vue
+++ b/curiefense/ui/src/components/TagAutocompleteInput.vue
@@ -9,6 +9,7 @@
              aria-haspopup="true"
              aria-controls="dropdown-menu"
              @keydown.enter="selectTag"
+             @keydown.space="selectTag"
              @keydown.down='focusNextSuggestion'
              @keydown.up='focusPreviousSuggestion'
              @keydown.esc='closeDropdown'
@@ -50,7 +51,10 @@ export default {
     selectionType: {
       type: String,
       validator(val) {
-        return ['single', 'multiple'].includes(val)
+        if (!val) {
+          return false
+        }
+        return ['single', 'multiple'].includes(val.toLowerCase())
       },
       default: 'single'
     }
@@ -93,7 +97,7 @@ export default {
     // Filtering the tags based on the input
     matches() {
       return this.tagsSuggestions?.filter((str) => {
-        return str.includes(this.currentTag)
+        return str.includes(this.currentTag.toLowerCase())
       })
     },
 
@@ -104,16 +108,16 @@ export default {
     currentTag: {
       get: function () {
         let currentTag
-        if (this?.selectionType === 'multiple') {
+        if (this?.selectionType.toLowerCase() === 'multiple') {
           const tags = this.tag.split(' ')
-          currentTag = tags[tags.length - 1]
+          currentTag = tags[tags.length - 1].trim()
         } else {
           currentTag = this.tag.trim()
         }
         return currentTag
       },
       set: function (currentTag) {
-        if (this.selectionType === 'multiple') {
+        if (this.selectionType.toLowerCase() === 'multiple') {
           const tags = this.tag.split(' ')
           tags[tags.length - 1] = currentTag
           this.tag = tags.join(' ')
@@ -143,11 +147,11 @@ export default {
     },
 
     tagChanged() {
-      this.$emit('tagChanged', this.tag)
+      this.$emit('tag-changed', this.tag)
     },
 
     tagSubmitted() {
-      this.$emit('tagSubmitted', this.tag)
+      this.$emit('tag-submitted', this.tag)
     },
 
     closeDropdown() {
@@ -162,7 +166,7 @@ export default {
     async selectTag() {
       if (this.focusedSuggestionIndex !== -1) {
         this.currentTag = this.matches[this.focusedSuggestionIndex]
-      } else if (!this.tagsSuggestions.includes(this.currentTag)) {
+      } else if (!this.tagsSuggestions.includes(this.currentTag.toLowerCase())) {
         await this.addUnknownTagToDB(this.currentTag)
       }
       this.tagSubmitted()
@@ -203,16 +207,19 @@ export default {
     },
 
     async addUnknownTagToDB(tag) {
+      tag = tag.toLowerCase()
       const response = await RequestsUtils.sendRequest('GET', `db/${this.db}/k/${this.key}/`)
       const document = {...{tags: []}, ...response.data}
       document.tags.push(tag)
+      this.tagsSuggestions = document.tags || []
+      this.tagsSuggestions.sort()
       return RequestsUtils.sendRequest('PUT', `db/${this.db}/k/${this.key}/`, document)
           .then((response) => {
-            console.log(`saved key [${this.key}] to database [${this.db}]`)
+            console.log(`saved tag [${tag}] to database, it will now be available for autocomplete!`)
             return response
           })
           .catch((error) => {
-            console.log(`failed saving key [${this.key}] to database [${this.db}]`)
+            console.log(`failed saving tag [${tag}]`)
             throw error
           })
     },

--- a/curiefense/ui/src/components/__tests__/GitHistory.spec.js
+++ b/curiefense/ui/src/components/__tests__/GitHistory.spec.js
@@ -142,14 +142,14 @@ describe('GitHistory.vue', () => {
             expect(firstDataRow.findAll('.restore-button').length).toEqual(0)
         })
 
-        test('should emit a restoreVersion event when restore button is clicked', async () => {
+        test('should emit a restore-version event when restore button is clicked', async () => {
             // 0 is the table header, 1 is our first data
             const firstDataRow = wrapper.findAll('tr').at(1)
             await firstDataRow.trigger('mouseover')
             const restoreButton = firstDataRow.find('.restore-button')
             await restoreButton.trigger('click')
-            expect(wrapper.emitted('restoreVersion')).toBeTruthy()
-            expect(wrapper.emitted('restoreVersion')[0]).toEqual([gitLog[0]])
+            expect(wrapper.emitted('restore-version')).toBeTruthy()
+            expect(wrapper.emitted('restore-version')[0]).toEqual([gitLog[0]])
         })
     })
 })

--- a/curiefense/ui/src/doc-editors/ACLEditor.vue
+++ b/curiefense/ui/src/doc-editors/ACLEditor.vue
@@ -50,11 +50,11 @@
                 <td>
                   <tag-autocomplete-input v-if="addNewColName === operation"
                                           ref="tagAutocompleteInput"
-                                          :clearInputAfterSelection="true"
-                                          :selectionType="'single'"
-                                          :autoFocus="true"
+                                          :clear-input-after-selection="true"
+                                          :selection-type="'single'"
+                                          :auto-focus="true"
                                           @keydown.esc="cancelAddNewTag"
-                                          @tagSubmitted="addNewEntry(operation, $event)">
+                                          @tag-submitted="addNewEntry(operation, $event)">
                   </tag-autocomplete-input>
                 </td>
                 <td class="is-size-7 is-18-px">
@@ -142,6 +142,7 @@ export default {
     },
 
     addNewEntry(section, entry) {
+      entry = entry.trim()
       if (entry && entry.length > 2) {
         this.selectedDoc[section].push(entry)
         this.$emit('update:selectedDoc', this.selectedDoc)

--- a/curiefense/ui/src/doc-editors/ProfilingListEditor.vue
+++ b/curiefense/ui/src/doc-editors/ProfilingListEditor.vue
@@ -25,9 +25,9 @@
             <div class="field">
               <label class="label is-small">Tags</label>
               <div class="control">
-                <tag-autocomplete-input :initialTag="selectedDocTags"
-                                        :selectionType="'multiple'"
-                                        @tagChanged="selectedDocTags = $event">
+                <tag-autocomplete-input :initial-tag="selectedDocTags"
+                                        :selection-type="'multiple'"
+                                        @tag-changed="selectedDocTags = $event">
                 </tag-autocomplete-input>
               </div>
               <p class="help">Separated by space.</p>

--- a/curiefense/ui/src/doc-editors/RateLimitsEditor.vue
+++ b/curiefense/ui/src/doc-editors/RateLimitsEditor.vue
@@ -173,9 +173,9 @@
                 <div class="column">
                   <div class="control has-icons-left">
                     <tag-autocomplete-input v-show="newIncludeOrExcludeEntry.key === 'tags'"
-                                            :initialTag="newIncludeOrExcludeEntry.value"
-                                            :selectionType="'multiple'"
-                                            @tagChanged="newIncludeOrExcludeEntry.value = $event">
+                                            :initial-tag="newIncludeOrExcludeEntry.value"
+                                            :selection-type="'multiple'"
+                                            @tag-changed="newIncludeOrExcludeEntry.value = $event">
                     </tag-autocomplete-input>
                     <input v-show="newIncludeOrExcludeEntry.key !== 'tags'"
                            v-model="newIncludeOrExcludeEntry.value" type="text" class="input is-small">
@@ -377,18 +377,6 @@ export default {
     updateEvent(option) {
       this.eventOption = { [option.type]: option.key }
     },
-    normalizeDocAction() {
-      // adding necessary fields to selectedDoc.action field
-      if (!this.selectedDoc.action) {
-        this.$set(this.selectedDoc, 'action', {})
-      }
-      if (!this.selectedDoc.action.params) {
-        this.$set(this.selectedDoc.action, 'params', {})
-      }
-      if (!this.selectedDoc.action.params.action) {
-        this.$set(this.selectedDoc.action.params, 'action', { type: 'default', params: {} })
-      }
-    },
     normalizeIncludesOrExcludes(value, include = true) {
       // converting includes/excludes from component arrays to selectedDoc objects
       const includeOrExcludeKey = include ? 'include' : 'exclude'
@@ -405,7 +393,6 @@ export default {
     }
   },
   mounted() {
-    this.normalizeDocAction()
     this.checkKeysValidity()
     this.checkIncludeOrExcludeValidity(true)
     this.checkIncludeOrExcludeValidity(false)
@@ -414,7 +401,6 @@ export default {
     selectedDoc(newValue) {
       this.includes = this.convertIncludesOrExcludes(newValue.include)
       this.excludes = this.convertIncludesOrExcludes(newValue.exclude)
-      this.normalizeDocAction()
       this.$forceUpdate()
     },
     includes(newValue) {

--- a/curiefense/ui/src/doc-editors/URLMapsEditor.vue
+++ b/curiefense/ui/src/doc-editors/URLMapsEditor.vue
@@ -476,7 +476,7 @@ export default {
     },
 
     referToRateLimit() {
-      this.$emit('switchDocType', 'limits')
+      this.$emit('switch-doc-type', 'limits')
     },
 
     wafacllimitProfileNames() {

--- a/curiefense/ui/src/doc-editors/__tests__/ACLEditor.spec.js
+++ b/curiefense/ui/src/doc-editors/__tests__/ACLEditor.spec.js
@@ -110,7 +110,7 @@ describe('ACLEditor.vue', () => {
         await Vue.nextTick()
         const newTag = 'test-tag'
         const tagAutocompleteInput = wrapper.findComponent(TagAutocompleteInput)
-        tagAutocompleteInput.vm.$emit('tagSubmitted', newTag)
+        tagAutocompleteInput.vm.$emit('tag-submitted', newTag)
         await Vue.nextTick()
         expect(wrapper.props('selectedDoc').bypass.includes(newTag)).toBeTruthy()
     })
@@ -121,7 +121,7 @@ describe('ACLEditor.vue', () => {
         await Vue.nextTick()
         const newTag = 't'
         const tagAutocompleteInput = wrapper.findComponent(TagAutocompleteInput)
-        tagAutocompleteInput.vm.$emit('tagSubmitted', newTag)
+        tagAutocompleteInput.vm.$emit('tag-submitted', newTag)
         await Vue.nextTick()
         expect(wrapper.props('selectedDoc').bypass.includes(newTag)).toBeFalsy()
     })

--- a/curiefense/ui/src/views/DBEditor.vue
+++ b/curiefense/ui/src/views/DBEditor.vue
@@ -186,7 +186,7 @@
         <hr/>
         <git-history :gitLog.sync="gitLog"
                      :apiPath.sync="gitAPIPath"
-                     @restoreVersion="restoreGitVersion"></git-history>
+                     @restore-version="restoreGitVersion"></git-history>
       </div>
     </div>
   </div>

--- a/curiefense/ui/src/views/DocumentEditor.vue
+++ b/curiefense/ui/src/views/DocumentEditor.vue
@@ -118,14 +118,14 @@
             :selectedDoc.sync="selectedDoc"
             :docs.sync="docs"
             :apiPath="documentAPIPath"
-            @switchDocType="switchDocType"
+            @switch-doc-type="switchDocType"
             ref="currentComponent"
         ></component>
         <hr/>
         <git-history v-if="selectedDocID"
                     :gitLog.sync="gitLog"
                     :apiPath.sync="gitAPIPath"
-                    @restoreVersion="restoreGitVersion"></git-history>
+                    @restore-version="restoreGitVersion"></git-history>
       </div>
     </div>
   </div>

--- a/curiefense/ui/src/views/VersionControl.vue
+++ b/curiefense/ui/src/views/VersionControl.vue
@@ -123,7 +123,7 @@
       <div class="content">
         <git-history :gitLog.sync="gitLog"
                      :apiPath.sync="gitAPIPath"
-                     @restoreVersion="restoreGitVersion">
+                     @restore-version="restoreGitVersion">
         </git-history>
       </div>
     </div>

--- a/curiefense/ui/src/views/__tests__/DBEditor.spec.js
+++ b/curiefense/ui/src/views/__tests__/DBEditor.spec.js
@@ -116,7 +116,7 @@ describe('DBEditor.vue', () => {
         axios.put.mockImplementation(() => Promise.resolve())
         putSpy = jest.spyOn(axios, 'put')
         const gitHistory = wrapper.findComponent(GitHistory)
-        gitHistory.vm.$emit('restoreVersion', wantedVersion)
+        gitHistory.vm.$emit('restore-version', wantedVersion)
         await Vue.nextTick()
         expect(putSpy).toHaveBeenCalledWith(`/conf/api/v1/db/system/v/${wantedVersion.version}/revert/`)
     })

--- a/curiefense/ui/src/views/__tests__/DocumentEditor.spec.js
+++ b/curiefense/ui/src/views/__tests__/DocumentEditor.spec.js
@@ -814,7 +814,7 @@ describe('DocumentEditor.vue', () => {
         axios.put.mockImplementation(() => Promise.resolve())
         putSpy = jest.spyOn(axios, 'put')
         const gitHistory = wrapper.findComponent(GitHistory)
-        gitHistory.vm.$emit('restoreVersion', wantedVersion)
+        gitHistory.vm.$emit('restore-version', wantedVersion)
         await Vue.nextTick()
         expect(putSpy).toHaveBeenCalledWith(`/conf/api/v1/configs/master/d/aclprofiles/v/${wantedVersion.version}/revert/`)
     })

--- a/curiefense/ui/src/views/__tests__/VersionControl.spec.js
+++ b/curiefense/ui/src/views/__tests__/VersionControl.spec.js
@@ -206,7 +206,7 @@ describe('VersionControl.vue', () => {
         axios.put.mockImplementation(() => Promise.resolve())
         putSpy = jest.spyOn(axios, 'put')
         const gitHistory = wrapper.findComponent(GitHistory)
-        gitHistory.vm.$emit('restoreVersion', wantedVersion)
+        gitHistory.vm.$emit('restore-version', wantedVersion)
         await Vue.nextTick()
         expect(putSpy).toHaveBeenCalledWith(`/conf/api/v1/configs/master/v/${wantedVersion.version}/revert/`)
     })


### PR DESCRIPTION
* Fixed bug where new tags wouldn't show up until input is refreshed + tests
* Fixed bug where new tags wouldn't be saved in multiple tags input in some occasions + tests
* Added insensitivity to tag autocomplete input type + tests
* Replaced all vue.js props and event names to use the recommended kebab-case