### PR TITLE
Helm: use es by default

### DIFF
--- a/curiefense/images/curielogger/init/start_curielogger.sh
+++ b/curiefense/images/curielogger/init/start_curielogger.sh
@@ -18,7 +18,7 @@ define_es_lifecycle_policy () {
 	if $CURL "${ELASTICSEARCH_URL}_ilm/policy/$ES_INDEX_NAME"|grep -q 200; then
 		echo "Elasticsearch lifecycle policy already exists."
 	else
-		if $CURL -X PUT "${ELASTICSEARCH_URL}_ilm/policy/$ES_INDEX_NAME" --data-binary @$INIT_DIR/es_lifecycle_policy.json|grep -q 200; then
+		if $CURL -X PUT "${ELASTICSEARCH_URL}_ilm/policy/$ES_INDEX_NAME" --data-binary "@$INIT_DIR/es_lifecycle_policy.json"|grep -q 200; then
 			echo "Elasticsearch lifecycle policy defined."
 		else
 			echo "Elasticsearch lifecycle policy creation failed, retrying."
@@ -32,12 +32,11 @@ define_es_index_template() {
 	if $CURL "${ELASTICSEARCH_URL}_index_template/$ES_INDEX_NAME"|grep -q 200; then
 		echo "Elastic index template already exists."
 	else
-        if [[ "$USE_DATA_STREAMS" == "true" ]];
-        then
-            DATA_STREAMS='"data_stream": {},'
-        fi
+		if [[ "$USE_DATA_STREAMS" == "true" ]]; then
+			DATA_STREAMS='"data_stream": {},'
+		fi
 
-		if sed -e "s/INDEX_NAME/$ES_INDEX_NAME/" -e "s/DATA_STREAMS/$DATA_STREAMS/" $INIT_DIR/index_template.json|$CURL -X PUT -d @- "${ELASTICSEARCH_URL}_index_template/$ES_INDEX_NAME"|grep -q 200; then
+		if sed -e "s/INDEX_NAME/$ES_INDEX_NAME/" -e "s/DATA_STREAMS/$DATA_STREAMS/" "$INIT_DIR/index_template.json"|$CURL -X PUT -d @- "${ELASTICSEARCH_URL}_index_template/$ES_INDEX_NAME"|grep -q 200; then
 			echo "Elastic index template created"
 		else
 			echo "Elastic index template creation failed, retrying."
@@ -49,14 +48,14 @@ define_es_index_template() {
 }
 
 define_es_initial_index () {
-    if [[ "$USE_DATA_STREAMS" == "true" ]]; then
+	if [[ "$USE_DATA_STREAMS" == "true" ]]; then
 		echo "Using datastreams, no need for initial index."
-        return
-    fi
+		return
+	fi
 	if $CURL "$ELASTICSEARCH_URL$ES_INDEX_NAME-000001"|grep -q 200; then
 		echo "Elastic index already exists."
 	else
-		if sed "s/INDEX_NAME/$ES_INDEX_NAME/" $INIT_DIR/es_index.json|$CURL -X PUT -d @- "$ELASTICSEARCH_URL$ES_INDEX_NAME-000001"|grep -q 200; then
+		if sed "s/INDEX_NAME/$ES_INDEX_NAME/" "$INIT_DIR/es_index.json"|$CURL -X PUT -d @- "$ELASTICSEARCH_URL$ES_INDEX_NAME-000001"|grep -q 200; then
 			echo "Elastic index and alias created."
 		else
 			echo "Elastic index and alias creation failed, retrying."

--- a/curiefense/images/uiserver/init/http.es.conf
+++ b/curiefense/images/uiserver/init/http.es.conf
@@ -1,0 +1,16 @@
+## this configuration replaces http.conf when curielogserver is not used
+server {
+    ### server port and name ###
+    listen          80;
+    server_name     _;
+
+    location /conf/api/v1/ {
+        proxy_pass  http://confserver/api/v1/;
+    }
+
+    location / {
+      root   /app;
+      index  index.html;
+      try_files $uri $uri/ /index.html;
+    }
+}

--- a/curiefense/images/uiserver/init/start_nginx.sh
+++ b/curiefense/images/uiserver/init/start_nginx.sh
@@ -6,4 +6,10 @@ fi
 if [ -f /run/secrets/uisslcrt/uisslcrt ]; then
 	sed -i 's/# TLS-K8S //' /init/nginx.conf
 fi
+
+if [ -n "$CURIELOGSERVER_DISABLED" ]; then
+	cp /init/http.es.conf /init/http.conf
+	cp /init/tls-k8s.es.conf /init/tls-k8s.conf
+fi
+
 /usr/sbin/nginx -g 'daemon off;'

--- a/curiefense/images/uiserver/init/tls-k8s.es.conf
+++ b/curiefense/images/uiserver/init/tls-k8s.es.conf
@@ -1,0 +1,20 @@
+## this configuration replaces tls-k8s.conf when curielogserver is not used
+server {
+    ### server port and name ###
+    listen          443 ssl;
+    server_name     _;
+
+    ssl_certificate     /run/secrets/uisslcrt/uisslcrt;
+    ssl_certificate_key /run/secrets/uisslkey/uisslkey;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location /conf/api/v1/ {
+        proxy_pass  http://confserver/api/v1/;
+    }
+
+    location / {
+      root   /app;
+      index  index.html;
+      try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-admin/templates/curielogserver-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-admin/templates/curielogserver-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.global.settings.curiefense_logdb_type "postgres" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,4 +83,5 @@ spec:
 {{- if .Values.global.tolerations }}
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
+{{- end }}
 {{- end }}

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-admin/templates/curielogserver-service.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-admin/templates/curielogserver-service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.global.settings.curiefense_logdb_type "postgres" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
     targetPort: 80
   selector:
     app.kubernetes.io/name: curielogserver
+{{- end }}

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-deployment.yaml
@@ -18,13 +18,18 @@ spec:
         app.kubernetes.io/name: uiserver
     spec:
       containers:
+      - name: uiserver
+      {{- if eq .Values.global.settings.curiefense_logdb_type "elasticsearch" }}
+        env:
+        - name: "CURIELOGSERVER_DISABLED"
+          value: "yes"
+      {{- end }}
       {{ if regexMatch ".*/.*:" .Values.global.images.uiserver }}
       {{/* The image name contains a version tag (e.g. for tests), do not append docker_tag */}}
-      - image: {{ .Values.global.images.uiserver }}
+        image: {{ .Values.global.images.uiserver }}
       {{ else }}
-      - image: {{ .Values.global.images.uiserver }}:{{ .Values.global.settings.docker_tag }}
+        image: {{ .Values.global.images.uiserver }}:{{ .Values.global.settings.docker_tag }}
       {{ end }}
-        name: uiserver
         ports:
         - containerPort: 80
           name: uiserver-http

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-configmap.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-configmap.yaml
@@ -64,7 +64,7 @@ data:
       }
     }
 
-  curieaccessmetrics.conf: |-
+  curiemetrics.conf: |-
     input {
       # This is the only input that should be declared here.
       # New inputs should be declared in the main inputs section..

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           readOnly: true
         resources:
           limits:
-            memory: "500Mi"
+            memory: "1Gi"
             cpu: "900m"
           requests:
             memory: "20Mi"

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
@@ -26,6 +26,8 @@ spec:
         - name: CURIEFENSE_ES_INDEX_NAME
           value: {{ .Values.global.settings.curiefense_es_index_name }}
         image: docker.elastic.co/logstash/logstash:7.10.1
+        # crashes if no tty is provided
+        tty: true
         ports:
         - containerPort: 5001
           name: logstash-http
@@ -35,9 +37,9 @@ spec:
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:
         - name: logstash-config
-          mountPath: "/usr/share/logstash/pipeline/curieaccessmetrics.conf"
+          mountPath: "/usr/share/logstash/pipeline/curiemetrics.conf"
           readOnly: true
-          subPath: curieaccessmetrics.conf
+          subPath: curiemetrics.conf
         - name: logstash-config
           mountPath: "/usr/share/logstash/pipeline/curieaccesslog.conf"
           readOnly: true

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: logstash-http
+          initialDelaySeconds: 30
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:
         - name: logstash-config

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
@@ -35,8 +35,17 @@ spec:
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:
         - name: logstash-config
-          mountPath: "/usr/share/logstash/pipeline"
+          mountPath: "/usr/share/logstash/pipeline/curieaccessmetrics.conf"
           readOnly: true
+          subPath: curieaccessmetrics.conf
+        - name: logstash-config
+          mountPath: "/usr/share/logstash/pipeline/curieaccesslog.conf"
+          readOnly: true
+          subPath: curieaccesslog.conf
+        - name: logstash-config
+          mountPath: "/usr/share/logstash/pipeline/input.conf"
+          readOnly: true
+          subPath: input.conf
         - name: logstash-config
           mountPath: "/usr/share/logstash/config/pipelines.yml"
           subPath: pipelines.yml

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
@@ -49,6 +49,8 @@ spec:
           value: "true"
         - name: CURIELOGGER_FLUENTD_URL
           value: "{{ .Values.global.settings.curiefense_fluentd_url }}"
+        - name: USE_DATA_STREAMS
+          value: "false"
 {{- end }}
         - name: CURIELOGGER_KIBANA_URL
           value: "{{ .Values.global.settings.curiefense_kibana_url }}"

--- a/deploy/curiefense-helm/curiefense/use-postgres.yaml
+++ b/deploy/curiefense-helm/curiefense/use-postgres.yaml
@@ -3,5 +3,4 @@
 # ./deploy.sh -f curiefense/use-es.yaml
 global:
   settings:
-    curiefense_logdb_type: 'elasticsearch'
-    curiefense_es_forwarder: 'logstash'
+    curiefense_logdb_type: 'postgres'

--- a/deploy/curiefense-helm/curiefense/values.yaml
+++ b/deploy/curiefense-helm/curiefense/values.yaml
@@ -26,7 +26,7 @@ global:
   settings:
     curieconf_manifest_url: 's3://curiefense-test01/prod/manifest.json'
     # supported types: 'postgres', 'elasticsearch'
-    curiefense_logdb_type: 'postgres'
+    curiefense_logdb_type: 'elasticsearch'
     # supported types: 'fluentd', 'logstash'
     curiefense_es_forwarder: 'logstash'
     # change curiefense_es_hosts if you supply your own elasticsearch server. Using several servers is not (yet?) fully supported by this chart

--- a/deploy/curiefense-helm/expose-services.yaml
+++ b/deploy/curiefense-helm/expose-services.yaml
@@ -107,3 +107,22 @@ spec:
     app.kubernetes.io/name: kibana
   type: NodePort
   externalTrafficPolicy: "Local"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: es-nodeport
+  name: es-nodeport
+  namespace: curiefense
+spec:
+  ports:
+  - name: 30200-9200
+    nodePort: 30200
+    port: 9200
+    protocol: TCP
+    targetPort: 9200
+  selector:
+    app.kubernetes.io/name: elasticsearch
+  type: NodePort
+  externalTrafficPolicy: "Local"

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -13,3 +13,6 @@ def pytest_addoption(parser):
     parser.addoption("--base-ui-url",
                      help="Base URL for the UI server",
                      default="http://localhost:30080")
+    parser.addoption("--elasticsearch-url",
+                     help="Elasticsearch URL (ex. http://localhost:9200)",
+                     default=False)


### PR DESCRIPTION
Makes the helm chart use logstash & elasticsearch by default.
Curielogserver is deployed only if postgres is used (with related fixes for the uiserver pod).
E2E functional tests now work with logstash.
Various fixes to make logstash work: configmap deployment fixed, memory resources increased.