### PR TITLE
Publish docker images on master push

### DIFF
--- a/.github/workflows/curiefense-build-images.yml
+++ b/.github/workflows/curiefense-build-images.yml
@@ -1,0 +1,24 @@
+name: Publish docker images
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'curiefense/**'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build and push the images
+        run: |
+            docker login -u "${{ secrets.DOCKER_HUB_USER }}" -p "${{ secrets.DOCKER_HUB_PASSWORD }}"
+            pushd curiefense/images
+            export DOCKER_TAG=$(echo ${GITHUB_REF#refs/heads/})
+            PUSH=1 ./build-docker-images.sh

--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -39,10 +39,8 @@ do
         echo "=================== $IMG:$DOCKER_TAG ====================="
         if tar -C "$image" -czh . | docker build -t "$IMG:$DOCKER_TAG" ${BUILD_OPT} -; then
             STB="ok"
-            docker tag "$IMG:$DOCKER_TAG" "$IMG:latest-dev"
             if [ -n "$PUSH" ]; then
                 docker push "$IMG:$DOCKER_TAG" && STP="ok" || STP="KO"
-                docker push "$IMG:latest-dev"
             else
                 STP="SKIP"
             fi

--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,5 +1,5 @@
 ENVOY_UID=0
-DOCKER_TAG=latest
+DOCKER_TAG=master
 
 CURIE_BUCKET_LINK=file:///bucket/prod/manifest.json
 #CURIE_BUCKET_LINK=s3://bucket/prod/manifest.json

--- a/deploy/curiefense-helm/curiefense/values.yaml
+++ b/deploy/curiefense-helm/curiefense/values.yaml
@@ -43,7 +43,7 @@ global:
     curiefense_bucket_type: 's3'
     curiefense_es_index_name: 'curieaccesslog'
     # docker_tag will be overridden by deploy.sh
-    docker_tag: 'latest'
+    docker_tag: 'master'
     redis_port: 6379
 
   requests:


### PR DESCRIPTION
This is the first step to keep our published images up to date. Note that the images use the name of the ref as the tag name. This means that pushes to master will result in a `master` tag name being used.

I'm unsure on whether `latest-dev` and `latest` are being used elsewhere but, truth is, they haven't been updated for a while so we may as well align the workflow now, once and for all. :smile: 