### PR TITLE
build-docker-images.sh: improve status reporting

### DIFF
--- a/.github/workflows/curiefense-publish-images.yml
+++ b/.github/workflows/curiefense-publish-images.yml
@@ -1,7 +1,7 @@
-name: Build docker images on pull request
+name: Publish docker images on push
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:
@@ -18,5 +18,7 @@ jobs:
 
       - name: Build and push the images
         run: |
+            docker login -u "${{ secrets.DOCKER_HUB_USER }}" -p "${{ secrets.DOCKER_HUB_PASSWORD }}"
             pushd curiefense/images
-            ./build-docker-images.sh
+            export DOCKER_TAG=$(echo ${GITHUB_REF#refs/heads/})
+            PUSH=1 ./build-docker-images.sh

--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -13,6 +13,7 @@ BUILD_OPT=${BUILD_OPT:-}
 
 declare -A status
 
+GLOBALSTATUS=0
 GITTAG="$(git describe --tag --long --dirty)"
 DOCKER_DIR_HASH="$(git rev-parse --short=12 HEAD:curiefense)"
 DOCKER_TAG="${DOCKER_TAG:-$GITTAG-$DOCKER_DIR_HASH}"
@@ -40,13 +41,19 @@ do
         if tar -C "$image" -czh . | docker build -t "$IMG:$DOCKER_TAG" ${BUILD_OPT} -; then
             STB="ok"
             if [ -n "$PUSH" ]; then
-                docker push "$IMG:$DOCKER_TAG" && STP="ok" || STP="KO"
+                if docker push "$IMG:$DOCKER_TAG"; then
+                    STP="ok"
+                else
+                    STP="KO"
+                    GLOBALSTATUS=1
+                fi
             else
                 STP="SKIP"
             fi
         else
             STB="KO"
             STP="SKIP"
+            GLOBALSTATUS=1
         fi
         status[$image]="build=$STB  push=$STP"
 done
@@ -66,3 +73,4 @@ else
     echo "To deploy this set of images later, export \"DOCKER_TAG=$DOCKER_TAG\" before running deploy.sh or docker-compose up"
 fi
 
+exit $GLOBALSTATUS


### PR DESCRIPTION
`build-docker-images.sh` used to always exit with status code=0
Now, its exit code is set to 1 if one image failed to build or push. This will allow detecting build breakages in CI, such as with https://github.com/curiefense/curiefense/runs/1936100146#step:3:4065

Also build images when a pull request targeting the `main` branch is received.
Signed-off-by: Xavier <xavier@reblaze.com>