### PR TITLE
build-docker-images.sh: improve status reporting

### DIFF
--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -13,6 +13,7 @@ BUILD_OPT=${BUILD_OPT:-}
 
 declare -A status
 
+GLOBALSTATUS=0
 GITTAG="$(git describe --tag --long --dirty)"
 DOCKER_DIR_HASH="$(git rev-parse --short=12 HEAD:curiefense)"
 DOCKER_TAG="${DOCKER_TAG:-$GITTAG-$DOCKER_DIR_HASH}"
@@ -40,13 +41,19 @@ do
         if tar -C "$image" -czh . | docker build -t "$IMG:$DOCKER_TAG" ${BUILD_OPT} -; then
             STB="ok"
             if [ -n "$PUSH" ]; then
-                docker push "$IMG:$DOCKER_TAG" && STP="ok" || STP="KO"
+                if docker push "$IMG:$DOCKER_TAG"; then
+                    STP="ok"
+                else
+                    STP="KO"
+                    GLOBALSTATUS=1
+                fi
             else
                 STP="SKIP"
             fi
         else
             STB="KO"
             STP="SKIP"
+            GLOBALSTATUS=1
         fi
         status[$image]="build=$STB  push=$STP"
 done
@@ -66,3 +73,4 @@ else
     echo "To deploy this set of images later, export \"DOCKER_TAG=$DOCKER_TAG\" before running deploy.sh or docker-compose up"
 fi
 
+exit $GLOBALSTATUS


### PR DESCRIPTION
This pull request is similar to #142, keeping only improvements to the build script, but not changes to the CI.

`build-docker-images.sh` used to always exit with status code=0
Now, its exit code is set to 1 if one image failed to build or push. This will allow detecting build breakages in CI, such as with https://github.com/curiefense/curiefense/runs/1936100146#step:3:4065

Signed-off-by: Xavier <xavier@reblaze.com>