### PR TITLE
logstash: increase initialDelaySeconds to 60s

### DIFF
--- a/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: logstash-http
-          initialDelaySeconds: 30
+          initialDelaySeconds: 60
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:
         - name: logstash-config


### PR DESCRIPTION
30s is sometimes not sufficient; logstash then gets killed in a loop because its livenessProbe fails.

Signed-off-by: Xavier <xavier@reblaze.com>