### PR TITLE
Improve the consistency of the ui in labels, titles, names, and multiple items input dividers

### DIFF
--- a/curiefense/ui/package-lock.json
+++ b/curiefense/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/curiefense/ui/package.json
+++ b/curiefense/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/curiefense/ui/src/components/TagAutocompleteInput.vue
+++ b/curiefense/ui/src/components/TagAutocompleteInput.vue
@@ -98,7 +98,7 @@ export default Vue.extend({
     },
 
     inputTitle(): string {
-      return this.selectionType.toLowerCase() === 'multiple' ? 'Tags separated by spaces' : 'Tag'
+      return this.selectionType.toLowerCase() === 'multiple' ? 'Space separated tags' : 'Tag'
     },
 
   },

--- a/curiefense/ui/src/doc-editors/URLMapsEditor.vue
+++ b/curiefense/ui/src/doc-editors/URLMapsEditor.vue
@@ -283,12 +283,12 @@
                           </div>
                           <div class="column is-4">
                             <div class="field">
-                              <label class="label is-small">WAF Profile</label>
+                              <label class="label is-small">WAF Policy</label>
                               <div class="control is-expanded">
                                 <div class="select is-fullwidth is-small">
                                   <select v-model="mapEntry.waf_profile"
                                           @change="emitDocUpdate"
-                                          title="WAF profile">
+                                          title="WAF policy">
                                     <option v-for="waf in wafProfileNames"
                                             :value="waf[0]"
                                             :key="waf[0]">
@@ -309,13 +309,13 @@
                             <hr/>
                             <div class="field">
                               <label class="label is-small">
-                                ACL Profile
+                                ACL Policy
                               </label>
                               <div class="control is-expanded">
                                 <div class="select is-fullwidth is-small">
                                   <select v-model="mapEntry.acl_profile"
                                           @change="emitDocUpdate"
-                                          title="ACL profile">
+                                          title="ACL policy">
                                     <option v-for="acl in aclProfileNames" :value="acl[0]" :key="acl[0]">
                                       {{ acl[1] }}
                                     </option>
@@ -333,7 +333,7 @@
                             </div>
                             <hr/>
                             <div class="field">
-                              <button title="Create new profile based on this one"
+                              <button title="Create a new profile based on this one"
                                       class="button is-small is-pulled-left is-light"
                                       @click="addNewProfile(mapEntry, idx)">
                                 <span class="icon"><i class="fas fa-code-branch"></i></span>

--- a/curiefense/ui/src/doc-editors/WAFEditor.vue
+++ b/curiefense/ui/src/doc-editors/WAFEditor.vue
@@ -158,7 +158,7 @@
                         <th class="has-text-centered">Matching Value</th>
                         <th class="has-text-centered">Restrict?</th>
                         <th class="has-text-centered">Mask?</th>
-                        <th class="has-text-centered">Exclude Sig</th>
+                        <th class="has-text-centered">Exclude WAF Rule</th>
                         <th class="has-text-centered">
                           <a v-show="newWAFLine !== tab"
                              class="has-text-grey-dark is-small" title="Add new parameter"
@@ -241,9 +241,12 @@
                           </label>
                         </td>
                         <td>
-                          <serialized-input :placeholder="'comma separated sig IDs'" :value="newEntry.exclusions"
-                                            :get-function="unpackExclusions" :set-function="packExclusions"
-                                            @blur="newEntry.exclusions = $event"></serialized-input>
+                          <serialized-input placeholder="Space separated rule IDs"
+                                            :value="newEntry.exclusions"
+                                            :get-function="unpackExclusions"
+                                            :set-function="packExclusions"
+                                            @blur="newEntry.exclusions = $event">
+                          </serialized-input>
                         </td>
                         <td class="has-text-centered">
                           <button title="Add new parameter" class="button is-light is-small" @click="addNewParameter">
@@ -286,8 +289,10 @@
                           </label>
                         </td>
                         <td>
-                          <serialized-input :placeholder="'comma separated sig IDs'" :value="entry.exclusions"
-                                            :get-function="unpackExclusions" :set-function="packExclusions"
+                          <serialized-input placeholder="Space separated rule IDs"
+                                            :value="entry.exclusions"
+                                            :get-function="unpackExclusions"
+                                            :set-function="packExclusions"
                                             @blur="entry.exclusions = $event">
                           </serialized-input>
                         </td>
@@ -337,8 +342,10 @@
                           </label>
                         </td>
                         <td>
-                          <serialized-input :placeholder="'comma separated sig IDs'" :value="entry.exclusions"
-                                            :get-function="unpackExclusions" :set-function="packExclusions"
+                          <serialized-input placeholder="Space separated rule IDs"
+                                            :value="entry.exclusions"
+                                            :get-function="unpackExclusions"
+                                            :set-function="packExclusions"
                                             @blur="entry.exclusions = $event">
                           </serialized-input>
                         </td>
@@ -431,13 +438,13 @@ export default Vue.extend({
         return ret
       }
 
-      return _.fromPairs(_.map(exclusions.split(','), (ex) => {
+      return _.fromPairs(_.map(exclusions.split(' '), (ex) => {
         return [ex.trim(), 1]
       }))
     },
 
     unpackExclusions(exclusions: string[]) {
-      return _.keys(exclusions).join(', ')
+      return _.keys(exclusions).join(' ')
     },
 
     genRowKey(tab: string, type: string, idx: number) {

--- a/curiefense/ui/src/views/DocumentSearch.vue
+++ b/curiefense/ui/src/views/DocumentSearch.vue
@@ -384,15 +384,21 @@ export default Vue.extend({
     },
 
     buildURLMapConnections(doc: SearchDocument) {
-      const connectedACL = []
-      const connectedWAF = []
-      const connectedRateLimits = []
+      const connectedACL: string[] = []
+      const connectedWAF: string[] = []
+      const connectedRateLimits: string[] = []
       for (let i = 0; i < doc.map.length; i++) {
         const map = doc.map[i]
-        connectedACL.push(map.acl_profile)
-        connectedWAF.push(map.waf_profile)
+        if (!connectedACL.includes(map.acl_profile)) {
+          connectedACL.push(map.acl_profile)
+        }
+        if (!connectedWAF.includes(map.waf_profile)) {
+          connectedWAF.push(map.waf_profile)
+        }
         for (let j = 0; j < map.limit_ids.length; j++) {
-          connectedRateLimits.push(map.limit_ids[j])
+          if (!connectedRateLimits.includes(map.limit_ids[j])) {
+            connectedRateLimits.push(map.limit_ids[j])
+          }
         }
       }
       doc.connectedACL = connectedACL

--- a/curiefense/ui/src/views/__tests__/DocumentSearch.spec.ts
+++ b/curiefense/ui/src/views/__tests__/DocumentSearch.spec.ts
@@ -162,6 +162,24 @@ describe('DocumentSearch.vue', () => {
             'waf_active': false,
             'limit_ids': ['f971e92459e2'],
           },
+          {
+            'name': 'name',
+            'match': '/foo',
+            'acl_profile': '__default__',
+            'acl_active': false,
+            'waf_profile': '__default__',
+            'waf_active': false,
+            'limit_ids': ['f971e92459e2'],
+          },
+          {
+            'name': 'name',
+            'match': '/foo',
+            'acl_profile': '__default__',
+            'acl_active': false,
+            'waf_profile': '__default__',
+            'waf_active': false,
+            'limit_ids': ['f971e92459e2'],
+          },
         ],
       },
     ]
@@ -332,6 +350,35 @@ describe('DocumentSearch.vue', () => {
       console.log = originalLog
       done()
     })
+  })
+
+  test('should not display duplicated values in connections even if connected twice', async () => {
+    const wantedIDsACL = ['5828321c37e0', '__default__']
+    const wantedIDsWAF = ['__default__']
+    const wantedIDsRateLimit = ['f971e92459e2']
+    // switch filter type to url map
+    const searchTypeSelection = wrapper.find('.search-type-selection')
+    searchTypeSelection.trigger('click')
+    const options = searchTypeSelection.findAll('option')
+    options.at(1).setSelected()
+    await Vue.nextTick()
+    const searchInput = wrapper.find('.search-input');
+    (searchInput.element as any).value = 'url map'
+    searchInput.trigger('input')
+    await Vue.nextTick()
+
+    // Get connections cell
+    const connectionsCell = wrapper.find('.doc-connections-cell')
+    const doc = (wrapper.vm as any).filteredDocs[0]
+
+    // check that url map exists without duplicated connections
+    expect(isItemInFilteredDocs(urlMapsDocs[0], 'urlmaps')).toBeTruthy()
+    expect(connectionsCell.text()).toContain(`ACL Policies:${wantedIDsACL.join('')}`)
+    expect(connectionsCell.text()).toContain(`WAF Policies:${wantedIDsWAF.join('')}`)
+    expect(connectionsCell.text()).toContain(`Rate Limits:${wantedIDsRateLimit.join('')}`)
+    expect(doc.connectedACL).toEqual(wantedIDsACL)
+    expect(doc.connectedWAF).toEqual(wantedIDsWAF)
+    expect(doc.connectedRateLimits).toEqual(wantedIDsRateLimit)
   })
 
   describe('filters', () => {


### PR DESCRIPTION
* Fix inputs with multiple items selection have no consistency, changed the multiple items input in waf rules to use space as dividers like other places - Closes #130 
* Fix some ui labels were not updated to the current name convention - Closes #134 
  - "Exclude Sig" was changed to “Exclude WAF Rule”
  - "sig IDs" was changed to "rule IDs"
  - "WAF Profile" was change to "WAF Policy"
  - "ACL Profile" was change to "ACL Policy"
* Fix Policies & Rules Search sometimes displays duplicated connection values. Will now filter out duplications and only display the same ID for a group (acl/waf/rate-limit/url-map) once per item - Closes #153 