### PR TITLE
Disallow match conflicts for URL Maps

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/v1/api.py
+++ b/curiefense/curieconf/server/curieconf/confserver/v1/api.py
@@ -181,6 +181,7 @@ m_document_mask = api.model('Mask for document', {
     "bypass": fields.List(fields.String()),
     "deny": fields.List(fields.String()),
     "force_deny": fields.List(fields.String()),
+    "match": fields.String(),
     '*': fields.Wildcard(fields.Raw()),
 })
 

--- a/curiefense/ui/package-lock.json
+++ b/curiefense/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1994,14 +1994,14 @@
       }
     },
     "@mdi/font": {
-      "version": "5.8.55",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-5.8.55.tgz",
-      "integrity": "sha512-8mrwfFBsmj+D67ZiGQSe5TU/lcWCtDyli2eshQ2fvLCZGRPqFMM23YQp4+JMOTpk5yMZKTeAwNWIYfITy76OHA=="
+      "version": "5.9.55",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-5.9.55.tgz",
+      "integrity": "sha512-jswRF6q3eq8NWpWiqct6q+6Fg/I7nUhrxYJfiEM8JJpap0wVJLQdbKtyS65GdlK7S7Ytnx3TTi/bmw+tBhkGmg=="
     },
     "@mdi/js": {
-      "version": "5.8.55",
-      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-5.8.55.tgz",
-      "integrity": "sha512-2bvln56SW6V/nSDC/0/NTu1bMF/CgSyZox8mcWbAPWElBN3UYIrukKDUckEER8ifr8X2YJl1RLKQqi7T7qLzmg=="
+      "version": "5.9.55",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-5.9.55.tgz",
+      "integrity": "sha512-BbeHMgeK2/vjdJIRnx12wvQ6s8xAYfvMmEAVsUx9b+7GiQGQ9Za8jpwp17dMKr9CgKRvemlAM4S7S3QOtEbp4A=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -4957,9 +4957,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.3.tgz",
-      "integrity": "sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -5218,9 +5218,9 @@
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
     },
     "bulma": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.1.tgz",
-      "integrity": "sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA=="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.2.tgz",
+      "integrity": "sha512-e14EF+3VSZ488yL/lJH0tR8mFWiEQVCMi/BQUMi2TGMBOk+zrDg4wryuwm/+dRSHJw0gMawp2tsW7X1JYUCE3A=="
     },
     "bulma-toast": {
       "version": "2.2.0",

--- a/curiefense/ui/package.json
+++ b/curiefense/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -14,11 +14,11 @@
     "lint:ts": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@mdi/font": "^5.8.55",
-    "@mdi/js": "^5.8.55",
+    "@mdi/font": "^5.9.55",
+    "@mdi/js": "^5.9.55",
     "axios": ">=0.21.1",
-    "bootstrap": "^4.5.0",
-    "bulma": "^0.9.0",
+    "bootstrap": "^4.6.0",
+    "bulma": "^0.9.2",
     "bulma-toast": "^2.2.0",
     "core-js": "^3.8.3",
     "jsoneditor": "^9.1.9",

--- a/curiefense/ui/src/assets/DatasetsUtils.ts
+++ b/curiefense/ui/src/assets/DatasetsUtils.ts
@@ -124,10 +124,11 @@ const newDocEntryFactory: { [key: string]: Function } = {
   },
 
   urlmaps(): URLMap {
+    const id = generateUUID2()
     return {
-      'id': generateUUID2(),
+      'id': id,
       'name': 'New URL Map',
-      'match': '__default__',
+      'match': `${id}.example.com`,
       'map': [
         {
           'match': '/',

--- a/curiefense/ui/src/assets/Utils.ts
+++ b/curiefense/ui/src/assets/Utils.ts
@@ -1,20 +1,30 @@
 import {ToastType} from 'bulma-toast'
 import * as bulmaToast from 'bulma-toast'
 
+const invalidityClasses = ` has-text-danger has-background-danger-light`
+
 // Validates an input based on given validator (Function / Boolean) and adds necessary classes if input is invalid
 const validateInput = (event: Event, validator: Function | boolean) => {
   let className = (event.target as HTMLElement)?.className
   let isValid
-  className = className.replace(' has-text-danger has-background-danger-light', '')
+  className = className.replace(`${invalidityClasses}`, '')
   if (typeof validator === 'function') {
     isValid = validator(event)
   } else {
     isValid = validator
   }
   if (!isValid) {
-    className += ' has-text-danger has-background-danger-light'
+    className += `${invalidityClasses}`
   }
   (event.target as HTMLElement).className = className
+  return isValid
+}
+
+// Clear invalidity classes from an input
+const clearInputValidationClasses = (element: HTMLElement) => {
+  let className = element.className
+  className = className.replace(`${invalidityClasses}`, '')
+  element.className = className
 }
 
 // Generates a unique name in a given entities list
@@ -86,6 +96,7 @@ const failureToast = (message: string) => {
 export default {
   name: 'Utils',
   validateInput,
+  clearInputValidationClasses,
   generateUniqueEntityName,
   downloadFile,
   toast,

--- a/curiefense/ui/src/assets/__tests__/Utils.spec.ts
+++ b/curiefense/ui/src/assets/__tests__/Utils.spec.ts
@@ -128,6 +128,42 @@ describe('Utils.ts', () => {
     })
   })
 
+  describe('clearInputValidationClasses function', () => {
+    let event: any
+    let validator
+    const invalidValidator = () => {
+      return false
+    }
+    beforeEach(() => {
+      event = {
+        target: {
+          className: 'is-big is-bird is-yellow',
+        },
+        type: 'input',
+      }
+    })
+
+    test('should remove classes from valid input element', async () => {
+      validator = invalidValidator
+      Utils.validateInput(event, validator)
+      Utils.clearInputValidationClasses(event.target as HTMLInputElement)
+      expect(event.target.className).not.toContain('has-text-danger')
+      expect(event.target.className).not.toContain('has-background-danger-light')
+    })
+
+    test('should not remove unrelated classes while validating', async () => {
+      validator = invalidValidator()
+      Utils.validateInput(event, validator)
+      expect(event.target.className).toContain('is-big')
+      expect(event.target.className).toContain('is-bird')
+      expect(event.target.className).toContain('is-yellow')
+      Utils.clearInputValidationClasses(event.target as HTMLInputElement)
+      expect(event.target.className).toContain('is-big')
+      expect(event.target.className).toContain('is-bird')
+      expect(event.target.className).toContain('is-yellow')
+    })
+  })
+
   describe('downloadFile function', () => {
     let fileName: string
     let fileType: string


### PR DESCRIPTION
* Add check for conflicting url maps and disable save on conflicts. Conflicts are check per domain match (no duplicate domain match between any two url maps) as well as map entries name matches (no duplicate map entry match between two entries of the same url map)
* Disable editing the default URL Maps default entry `/` and default domain match `__default__`
* Add Snyk package.json update suggestions
* Add Utils function which removes the classes we add to mark an input element as invalid if present

Closes #128 
Closes #135 