### PR TITLE
Policies & Rules url path reset fix

### DIFF
--- a/curiefense/ui/package-lock.json
+++ b/curiefense/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/curiefense/ui/package.json
+++ b/curiefense/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
+++ b/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
@@ -925,6 +925,40 @@ describe('DocumentEditor.vue', () => {
     })
   })
 
+  test('should not switch doc type when switching branches', async (done) => {
+    const docTypeSelection = wrapper.find('.doc-type-selection')
+    docTypeSelection.trigger('click')
+    const docTypeOptions = docTypeSelection.findAll('option')
+    docTypeOptions.at(2).setSelected()
+    await Vue.nextTick()
+    const branchSelection = wrapper.find('.branch-selection')
+    branchSelection.trigger('click')
+    const branchOptions = branchSelection.findAll('option')
+    branchOptions.at(1).setSelected()
+    // allow all requests to finish
+    setImmediate(() => {
+      expect((docTypeSelection.element as any).selectedIndex).toEqual(2)
+      done()
+    })
+  })
+
+  test('should not switch selected doc when switching branches', async (done) => {
+    const docSelection = wrapper.find('.doc-selection')
+    docSelection.trigger('click')
+    const docOptions = docSelection.findAll('option')
+    docOptions.at(1).setSelected()
+    await Vue.nextTick()
+    const branchSelection = wrapper.find('.branch-selection')
+    branchSelection.trigger('click')
+    const branchOptions = branchSelection.findAll('option')
+    branchOptions.at(1).setSelected()
+    // allow all requests to finish
+    setImmediate(() => {
+      expect((docSelection.element as any).selectedIndex).toEqual(1)
+      done()
+    })
+  })
+
   test('should be able to switch doc types through dropdown', (done) => {
     const docTypeSelection = wrapper.find('.doc-type-selection')
     docTypeSelection.trigger('click')


### PR DESCRIPTION
Change Policies & Rules to not reset the url path when switching branhes or reverting a document to a previous state

* Fix Policies & Rules reset path when switching branches
* Fix Policies & Rules reset path when reverting a document

Closes #161 