### PR TITLE
curielogger: Use a map as outputs default

### DIFF
--- a/curiefense/curielogger/curielogger.yml
+++ b/curiefense/curielogger/curielogger.yml
@@ -1,14 +1,14 @@
 log_level: debug
 outputs:
-    - elasticsearch: &es
-        enabled: false
-        initialize: true
-        overwrite: true
-        use_data_stream: true
-        url: "http://elasticsearch:9200/"
-        kibana_url: "http://kibana:5601"
+    elasticsearch: &es
+      enabled: false
+      initialize: true
+      overwrite: true
+      use_data_stream: true
+      url: "http://elasticsearch:9200/"
+      kibana_url: "http://kibana:5601"
 
-    - logstash:
-        enabled: false
-        url: "http://logstash:5001/"
-        elasticsearch: *es
+    logstash:
+      enabled: false
+      url: "http://logstash:5001/"
+      elasticsearch: *es


### PR DESCRIPTION
This uses a map as the outputs default value in the default curielogger.yaml so that
it is possible to overwrite the values using environment variables.

This is not the best, long-term, solution as outputs is expected to be a slice rather
than a map.

closes #190