### PR TITLE
[curielogger] Only allow one output per backend

### DIFF
--- a/curiefense/curielogger/curielogger.yml
+++ b/curiefense/curielogger/curielogger.yml
@@ -1,14 +1,14 @@
 log_level: info
 outputs:
-  - elasticsearch: &es
-      enabled: false
-      initialize: true
-      overwrite: true
-      use_data_stream: true
-      url: "http://elasticsearch:9200/"
-      kibana_url: "http://kibana:5601"
+  elasticsearch: &es
+    enabled: false
+    initialize: true
+    overwrite: true
+    use_data_stream: true
+    url: "http://elasticsearch:9200/"
+    kibana_url: "http://kibana:5601"
 
-  - logstash:
-      enabled: true
-      url: "http://logstash:5001/"
-      elasticsearch: *es
+  logstash:
+    enabled: false
+    url: "http://logstash:5001/"
+    elasticsearch: *es

--- a/curiefense/curielogger/curielogger/config.go
+++ b/curiefense/curielogger/curielogger/config.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Config struct {
-	LogLevel        string          `mapstructure:"log_level" validate:"one_of=info,debug,error"`
-	ChannelCapacity int             `mapstructure:"channel_capacity"`
-	Outputs         []OutputsConfig `mapstructure:"outputs,omitempty"`
+	LogLevel        string        `mapstructure:"log_level" validate:"one_of=info,debug,error"`
+	ChannelCapacity int           `mapstructure:"channel_capacity"`
+	Outputs         OutputsConfig `mapstructure:"outputs,omitempty"`
 }
 
 type OutputsConfig struct {

--- a/curiefense/curielogger/curielogger/main.go
+++ b/curiefense/curielogger/curielogger/main.go
@@ -833,25 +833,22 @@ func main() {
 	// 	}
 	// }
 
-	for _, output := range config.Outputs {
-		// ElasticSearch
-		if output.Elasticsearch.Enabled {
-			log.Printf("[DEBUG] Elasticsearch enabled with URL: %s", output.Elasticsearch.Url)
-			es := ElasticsearchLogger{config: output.Elasticsearch}
-			// go configRetry(&es)
-			es.Configure(config.ChannelCapacity)
-			loggers = append(loggers, &es)
-		}
+	// ElasticSearch
+	if config.Outputs.Elasticsearch.Enabled {
+		log.Printf("[DEBUG] Elasticsearch enabled with URL: %s", config.Outputs.Elasticsearch.Url)
+		es := ElasticsearchLogger{config: config.Outputs.Elasticsearch}
+		// go configRetry(&es)
+		es.Configure(config.ChannelCapacity)
+		loggers = append(loggers, &es)
+	}
 
-		// Logstash
-		if output.Logstash.Enabled {
-			log.Printf("[DEBUG] Logstash enabled with URL: %s", output.Logstash.Url)
-			ls := logstashLogger{config: output.Logstash}
-			// go configRetry(&ls)
-			ls.Configure(config.ChannelCapacity)
-			loggers = append(loggers, &ls)
-		}
-
+	// Logstash
+	if config.Outputs.Logstash.Enabled {
+		log.Printf("[DEBUG] Logstash enabled with URL: %s", config.Outputs.Logstash.Url)
+		ls := logstashLogger{config: config.Outputs.Logstash}
+		// go configRetry(&ls)
+		ls.Configure(config.ChannelCapacity)
+		loggers = append(loggers, &ls)
 	}
 
 	// Fluentd


### PR DESCRIPTION
This switches from allowuing users to configure multiple outputs for the same
backend to a single one. Users that need to talk to multiple ES, should use Logstash.
Same applies for other outputs