### PR TITLE
Reduces curielogger's verbosity

### DIFF
--- a/curiefense/curielogger/curielogger/main.go
+++ b/curiefense/curielogger/curielogger/main.go
@@ -733,7 +733,6 @@ func (s grpcServerParams) StreamAccessLogs(x als.AccessLogService_StreamAccessLo
 			}
 
 			for _, l := range s.loggers {
-				log.Print(l)
 				l.SendEntry(log_entry)
 			}
 		}


### PR DESCRIPTION
Do not log every single request to stdout.