### PR TITLE
Add default labels to our github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
Add default labels to our github issue templates

* Add label - bug_report template will now be opened with 'bug' label
* Add label - feature_request template will now be opened with 'enhancement' label

Closes #230

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>