### PR TITLE
Make all e2e tests pass

### DIFF
--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -45,7 +45,7 @@ jobs:
             echo "-- Run e2e tests --"
             pushd e2e
             IP=127.0.0.1
-            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude)' .
+            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml .
             popd
 
             # Print logs from all services for debug

--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -45,7 +45,7 @@ jobs:
             echo "-- Run e2e tests --"
             pushd e2e
             IP=127.0.0.1
-            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude or test_ratelimit_countby_ipv4 or test_ratelimit_countby_provider or test_ratelimit_countby_company or test_ratelimit_countby_country)' .
+            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude)' .
             popd
 
             # Print logs from all services for debug

--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -45,7 +45,7 @@ jobs:
             echo "-- Run e2e tests --"
             pushd e2e
             IP=127.0.0.1
-            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ipv4 or test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude or test_ratelimit_countby_ipv4 or test_ratelimit_countby_provider or test_ratelimit_countby_company or test_ratelimit_countby_country)' .
+            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude or test_ratelimit_countby_ipv4 or test_ratelimit_countby_provider or test_ratelimit_countby_company or test_ratelimit_countby_country)' .
             popd
 
             # Print logs from all services for debug

--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -45,7 +45,7 @@ jobs:
             echo "-- Run e2e tests --"
             pushd e2e
             IP=127.0.0.1
-            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ipv4 or test_wafsig or test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude or test_ratelimit_countby_ipv4 or test_ratelimit_countby_provider or test_ratelimit_countby_company or test_ratelimit_countby_country)' .
+            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ipv4 or test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude or test_ratelimit_countby_ipv4 or test_ratelimit_countby_provider or test_ratelimit_countby_company or test_ratelimit_countby_country)' .
             popd
 
             # Print logs from all services for debug

--- a/curiefense/curieproxy/lua/limit.lua
+++ b/curiefense/curieproxy/lua/limit.lua
@@ -143,8 +143,17 @@ function build_key(request_map, limit_set, url_map_name)
         local section, name = next(entry)
         -- handle:logDebug(string.format("limit build_key -- iterate key entrie's section %s, name %s", section, name))
         if section and name then
-            local entry = request_map[section][name]
             -- handle:logDebug(string.format("limit build_key -- iterate key request_map[section][name] %s", request_map[section][name]))
+            local entry
+            if section == 'attrs' and name == 'country' then
+                entry = request_map.geo.country.iso
+            elseif section == 'attrs' and name == 'company' then
+                entry = request_map.geo.company
+            elseif section == 'attrs' and name == 'asn' then
+                entry = request_map.geo.asn
+            else
+                entry = request_map[section][name]
+            end
             if entry then
                 key = key .. entry
             else

--- a/curiefense/curieproxy/lua/limit.lua
+++ b/curiefense/curieproxy/lua/limit.lua
@@ -43,8 +43,18 @@ function should_exclude(request_map, limit_set)
     local exclude = false
     for section, entries in pairs(limit_set["exclude"]) do
         for name, value in pairs(entries) do
-            if request_map[section][name] then
-                if re_match(request_map[section][name], value) then
+            local entry
+            if section == 'attrs' and name == 'country' then
+                entry = request_map.geo.country.iso
+            elseif section == 'attrs' and name == 'company' then
+                entry = request_map.geo.company
+            elseif section == 'attrs' and name == 'asn' then
+                entry = request_map.geo.asn
+            else
+                entry = request_map[section][name]
+            end
+            if entry then
+                if re_match(entry, value) then
                     -- request_map.handle:logDebug(string.format("limit excluding (%s)[%s]=='%s'", section, name, value))
                     exclude = true
                     break
@@ -59,8 +69,18 @@ function should_include(request_map, limit_set)
     local include = true
     for section, entries in pairs(limit_set["include"]) do
         for name, value in pairs(entries) do
-            if request_map[section][name] then
-                if not re_match(request_map[section][name], value) then
+            local entry
+            if section == 'attrs' and name == 'country' then
+                entry = request_map.geo.country.iso
+            elseif section == 'attrs' and name == 'company' then
+                entry = request_map.geo.company
+            elseif section == 'attrs' and name == 'asn' then
+                entry = request_map.geo.asn
+            else
+                entry = request_map[section][name]
+            end
+            if entry then
+                if not re_match(entry, value) then
                     -- request_map.handle:logDebug(string.format("limit NOT including (%s)[%s]=='%s'", section, name, value))
                     include = false
                     break
@@ -143,7 +163,6 @@ function build_key(request_map, limit_set, url_map_name)
         local section, name = next(entry)
         -- handle:logDebug(string.format("limit build_key -- iterate key entrie's section %s, name %s", section, name))
         if section and name then
-            -- handle:logDebug(string.format("limit build_key -- iterate key request_map[section][name] %s", request_map[section][name]))
             local entry
             if section == 'attrs' and name == 'country' then
                 entry = request_map.geo.country.iso

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -1505,15 +1505,21 @@ class TestWAFParamsConstraints:
 
 
 @pytest.fixture(
-    scope="session", params=[(100140, "htaccess"), (100116, "../../../../../")]
+    scope="session", params=[(100140, "htaccess"), (100112, "../../../../../")]
 )
 def wafrules(request):
     return request.param
 
 
 class TestWAFRules:
-    def test_wafsig(self, default_config, target, section, wafrules):
+    def test_wafsig(self, wafparam_config, target, section, wafrules, ignore_alphanum):
         ruleid, rulestr = wafrules
-        assert not target.is_reachable(
-            f"/wafsig-{section}", **{section: {"key": rulestr}}
-        ), f"Reachable despite matching rule {ruleid}"
+        has_nonalpha = "." in rulestr
+        if ignore_alphanum and not has_nonalpha:
+            assert target.is_reachable(
+                f"/wafsig-{section}", **{section: {"key": rulestr}}
+            ), f"Unreachable despite ignore_alphanum=True for rule {ruleid}"
+        else:
+            assert not target.is_reachable(
+                f"/wafsig-{section}", **{section: {"key": rulestr}}
+            ), f"Reachable despite matching rule {ruleid}"

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -221,7 +221,7 @@ def default_config(cli):
     cli.publish_and_apply()
 
 
-@pytest.fixture(scope="session", params=["headers", "cookies", "params"])
+@pytest.fixture(scope="function", params=["headers", "cookies", "params"])
 def section(request):
     return request.param
 
@@ -1440,12 +1440,12 @@ def wafparam_config(cli, request, ignore_alphanum):
     cli.publish_and_apply()
 
 
-@pytest.fixture(scope="session", params=["name", "regex"])
+@pytest.fixture(scope="function", params=["name", "regex"])
 def name_regex(request):
     return request.param
 
 
-@pytest.fixture(scope="session", params=["restrict", "norestrict"])
+@pytest.fixture(scope="function", params=["restrict", "norestrict"])
 def restrict(request):
     return request.param
 
@@ -1505,7 +1505,7 @@ class TestWAFParamsConstraints:
 
 
 @pytest.fixture(
-    scope="session", params=[(100140, "htaccess"), (100112, "../../../../../")]
+    scope="function", params=[(100140, "htaccess"), (100112, "../../../../../")]
 )
 def wafrules(request):
     return request.param


### PR DESCRIPTION
Code fixes in both tests & curieproxy code that get us to 0 failing e2e tests.

Checks added to the LUA code adds some duplication, but that could be addressed later.

Closes #254 