### PR TITLE
make build-docker-images.sh compatible with macos

### DIFF
--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -39,7 +39,10 @@ do
         IMG=${REPO}/$image
         echo "=================== $IMG:$DOCKER_TAG ====================="
         # shellcheck disable=SC2086
-        if tar -C "$image" -czh . | docker build -t "$IMG:$DOCKER_TAG" ${BUILD_OPT} -; then
+        # a temporary file is needed on macos -- docker complains otherwise
+        TMPFILE=(mktemp)
+        tar -czhf "$TMPFILE" -C "$image" .
+        if docker build -t "$IMG:$DOCKER_TAG" ${BUILD_OPT} - < "$TMPFILE"; then
             STB="ok"
             if [ -n "$PUSH" ]; then
                 if docker push "$IMG:$DOCKER_TAG"; then


### PR DESCRIPTION
fixes #256
1/ swap arguments (-C should come after -czhf with bsdtar)

2/ use a temporary file. If not, the following error occurs:
Error processing tar file(gzip: invalid header)

Signed-off-by: Xavier <xavier@reblaze.com>
Tested-by: Justin Dorfman <justindorfman@gmail.com>