### PR TITLE
Add a webhook output

### DIFF
--- a/curiefense/curielogger/curielogger/config.go
+++ b/curiefense/curielogger/curielogger/config.go
@@ -16,6 +16,7 @@ type Config struct {
 type OutputsConfig struct {
 	Elasticsearch ElasticsearchConfig `mapstructure:"elasticsearch,omitempty"`
 	Logstash      LogstashConfig      `mapstructure:"logstash,omitempty"`
+	Webhook       WebhookConfig       `mapstructure:"webhook,omitempty"`
 }
 
 func LoadConfig() (config Config, err error) {

--- a/curiefense/curielogger/curielogger/main.go
+++ b/curiefense/curielogger/curielogger/main.go
@@ -332,6 +332,13 @@ func main() {
 		go configRetry(&grpcParams, &ls)
 	}
 
+	// Webhoook
+	if config.Outputs.Webhook.Enabled {
+		log.Printf("[DEBUG] Webhook enabled with URL: %s", config.Outputs.Webhook.Url)
+		wh := webhookLogger{config: config.Outputs.Webhook}
+		go configRetry(&grpcParams, &wh)
+	}
+
 	// Fluentd
 	if check_env_flag("CURIELOGGER_USES_FLUENTD") {
 		fd := fluentdLogger{}

--- a/curiefense/curielogger/curielogger/outputs.webhook.go
+++ b/curiefense/curielogger/curielogger/outputs.webhook.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+//  _    ___   ___ ___ _____ _   ___ _  _
+// | |  / _ \ / __/ __|_   _/_\ / __| || |
+// | |_| (_) | (_ \__ \ | |/ _ \\__ \ __ |
+// |____\___/ \___|___/ |_/_/ \_\___/_||_|
+// WEBHOOK
+
+type WebhookConfig struct {
+	Enabled bool   `mapstructure:"enabled"`
+	Url     string `mapstructure:"url"`
+}
+
+type webhookLogger struct {
+	logger
+	config WebhookConfig
+}
+
+func (l *webhookLogger) Configure(channel_capacity int) error {
+	l.name = "Webhook"
+	ch := make(chan LogEntry, channel_capacity)
+	l.channel = ch
+	l.do_insert = l.InsertEntry
+
+	return nil
+}
+
+func (l *webhookLogger) InsertEntry(e LogEntry) bool {
+	log.Printf("[DEBUG] Webhook insertion!")
+	e.cfLog.Tags = append(e.cfLog.Tags, "curieaccesslog")
+	j, err := json.Marshal(e.cfLog)
+	if err == nil {
+		_, err := http.Post(l.config.Url, "application/json", bytes.NewReader(j))
+		if err != nil {
+			log.Printf("ERROR: could not POST log entry: %v", err)
+			return false
+		}
+	} else {
+		log.Printf("[ERROR] Could not convert protobuf entry into json for ES insertion.")
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Allow to configure a webhook logger. Simple HTTP URL that accepts
a json body, with the request's log.

Future versions should add support for TLS, authentication, throthling,
retries, etc.