### PR TITLE
[e2e] fix arguments passed to deploy.sh. Fixes e2e tests.

### DIFF
--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Publish Unit Test Results
         # TODO implement https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories
         uses: EnricoMi/publish-unit-test-result-action@ea8720de4a2e723f8204d44fc0178744cf401c1a
-        if: always()
         with:
           files: e2e/pytest.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -66,3 +65,15 @@ jobs:
           comment_on_pr: true
           report_individual_runs: true
           deduplicate_classes_by_file_name: false
+        if: >
+          always() &&
+          github.event.sender.login != 'dependabot[bot]' &&
+          ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unit Test Results
+          path: |
+            e2e/pytest.xml

--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -1,7 +1,7 @@
 name: Run e2e tests on docker-compose
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "deploy/**"
       - "curiefense/**"

--- a/.github/workflows/e2e-minikube-fluentd.yml
+++ b/.github/workflows/e2e-minikube-fluentd.yml
@@ -1,7 +1,7 @@
-name: Run e2e tests on minikube
+name: Run e2e tests on minikube with fluentd
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "deploy/**"
       - "curiefense/**"

--- a/.github/workflows/e2e-minikube-fluentd.yml
+++ b/.github/workflows/e2e-minikube-fluentd.yml
@@ -60,9 +60,7 @@ jobs:
             pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ipv4 or test_wafsig or test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude or test_ratelimit_countby_ipv4 or test_ratelimit_countby_provider or test_ratelimit_countby_company or test_ratelimit_countby_country or test_ratelimit_event_ipv4 or test_ratelimit_event_ipv6 or test_ratelimit_event_provider or test_ratelimit_event_tag or test_ratelimit_event_company or test_ratelimit_event_country or test_logs or test_ip_asn or test_geo or test_ipv6 or test_ratelimit_scope_path_include or test_ratelimit_scope_path_include_exclud or test_ratelimit_scope_uri_include or test_ratelimit_scope_uri_include_exclud or test_ratelimit_scope_method_include or test_ratelimit_scope_method_exclude or test_ratelimit_scope_query_include or test_ratelimit_scope_query_exclude or test_ratelimit_scope_authority_include or test_ratelimit_scope_authority_exclude or test_ratelimit_countby_ipv6 or test_ratelimit_countby_uri or test_ratelimit_countby_path or test_ratelimit_countby_query or test_ratelimit_countby_method or test_ratelimit_countby_authority or test_ratelimit_event_uri or test_ratelimit_event_path or test_ratelimit_event_query or test_ratelimit_event_method or test_ratelimit_event_authority or test_ipv6 or test_country or test_asn or test_ratelimit_scope_include or test_ratelimit_scope_include_exclude or test_ratelimit_scope_exclude or test_ratelimit_countby_section or test_ratelimit_countby2_section or test_ratelimit_countby_2sections or test_ratelimit_event_section or test_length_overlong or test_length_short or test_count_few or test_count_toomany or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_non_allowlisted_value_restrict or test_non_allowlisted_value_norestrict_nowafmatch or test_non_allowlisted_value_norestrict_wafmatch or test_non_allowlisted_value_norestrict_wafmatch_excludesig or test_allowlisted_value or test_allowlisted_value or test_non_allowlisted_value_restrict or test_non_allowlisted_value_norestrict_nowafmatch or test_non_allowlisted_value_norestrict_wafmatch or test_non_allowlisted_value_norestrict_wafmatch_excludesig)' .
 
       - name: Publish Unit Test Results
-        # TODO implement https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories
         uses: EnricoMi/publish-unit-test-result-action@ea8720de4a2e723f8204d44fc0178744cf401c1a
-        if: always()
         with:
           files: e2e/pytest.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,3 +70,15 @@ jobs:
           comment_on_pr: true
           report_individual_runs: true
           deduplicate_classes_by_file_name: false
+        if: >
+          always() &&
+          github.event.sender.login != 'dependabot[bot]' &&
+          ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unit Test Results
+          path: |
+            e2e/pytest.xml

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,9 +59,7 @@ jobs:
             pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v1/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml -k 'not (test_ipv4 or test_wafsig or test_ratelimit_scope_ipv4_include or test_ratelimit_scope_ipv4_exclude or test_ratelimit_scope_country_include or test_ratelimit_scope_country_exclude or test_ratelimit_scope_company_include or test_ratelimit_scope_company_exclude or test_ratelimit_scope_provider_include or test_ratelimit_scope_provider_exclude or test_ratelimit_countby_ipv4 or test_ratelimit_countby_provider or test_ratelimit_countby_company or test_ratelimit_countby_country or test_ratelimit_event_ipv4 or test_ratelimit_event_ipv6 or test_ratelimit_event_provider or test_ratelimit_event_tag or test_ratelimit_event_company or test_ratelimit_event_country or test_logs or test_ip_asn or test_geo or test_ipv6 or test_ratelimit_scope_path_include or test_ratelimit_scope_path_include_exclud or test_ratelimit_scope_uri_include or test_ratelimit_scope_uri_include_exclud or test_ratelimit_scope_method_include or test_ratelimit_scope_method_exclude or test_ratelimit_scope_query_include or test_ratelimit_scope_query_exclude or test_ratelimit_scope_authority_include or test_ratelimit_scope_authority_exclude or test_ratelimit_countby_ipv6 or test_ratelimit_countby_uri or test_ratelimit_countby_path or test_ratelimit_countby_query or test_ratelimit_countby_method or test_ratelimit_countby_authority or test_ratelimit_event_uri or test_ratelimit_event_path or test_ratelimit_event_query or test_ratelimit_event_method or test_ratelimit_event_authority or test_ipv6 or test_country or test_asn or test_ratelimit_scope_include or test_ratelimit_scope_include_exclude or test_ratelimit_scope_exclude or test_ratelimit_countby_section or test_ratelimit_countby2_section or test_ratelimit_countby_2sections or test_ratelimit_event_section or test_length_overlong or test_length_short or test_count_few or test_count_toomany or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_allowlisted_value or test_non_allowlisted_value_restrict or test_non_allowlisted_value_norestrict_nowafmatch or test_non_allowlisted_value_norestrict_wafmatch or test_non_allowlisted_value_norestrict_wafmatch_excludesig or test_allowlisted_value or test_allowlisted_value or test_non_allowlisted_value_restrict or test_non_allowlisted_value_norestrict_nowafmatch or test_non_allowlisted_value_norestrict_wafmatch or test_non_allowlisted_value_norestrict_wafmatch_excludesig)' .
 
       - name: Publish Unit Test Results
-        # TODO implement https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories
         uses: EnricoMi/publish-unit-test-result-action@ea8720de4a2e723f8204d44fc0178744cf401c1a
-        if: always()
         with:
           files: e2e/pytest.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -71,3 +69,15 @@ jobs:
           comment_on_pr: true
           report_individual_runs: true
           deduplicate_classes_by_file_name: false
+        if: >
+          always() &&
+          github.event.sender.login != 'dependabot[bot]' &&
+          ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unit Test Results
+          path: |
+            e2e/pytest.xml

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: Run e2e tests on minikube
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "deploy/**"
       - "curiefense/**"

--- a/.github/workflows/helm-v2-deploy.yml
+++ b/.github/workflows/helm-v2-deploy.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "deploy/**"
       - "curiefense/**"

--- a/.github/workflows/helm-v2-deploy.yml
+++ b/.github/workflows/helm-v2-deploy.yml
@@ -1,3 +1,5 @@
+name: Run e2e tests on Helm v2
+
 on:
   pull_request:
     paths:
@@ -50,9 +52,7 @@ jobs:
             deploy/deploy-ci.sh
 
       - name: Publish Unit Test Results
-        # TODO implement https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories
         uses: EnricoMi/publish-unit-test-result-action@ea8720de4a2e723f8204d44fc0178744cf401c1a
-        if: always()
         with:
           files: e2e/pytest.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,3 +62,15 @@ jobs:
           comment_on_pr: true
           report_individual_runs: true
           deduplicate_classes_by_file_name: false
+        if: >
+          always() &&
+          github.event.sender.login != 'dependabot[bot]' &&
+          ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unit Test Results
+          path: |
+            e2e/pytest.yml

--- a/.github/workflows/run-curieconf-tests.yml
+++ b/.github/workflows/run-curieconf-tests.yml
@@ -50,7 +50,6 @@ jobs:
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@70b5dd187f73f17a3b4ac0191e22bb9eec9bbb25
-        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: Unit Test Results
@@ -60,3 +59,15 @@ jobs:
           files: junit.xml
           report_individual_runs: true
           deduplicate_classes_by_file_name: false
+        if: >
+          always() &&
+          github.event.sender.login != 'dependabot[bot]' &&
+          ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unit Test Results
+          path: |
+            junit.xml

--- a/.github/workflows/run-curieconf-tests.yml
+++ b/.github/workflows/run-curieconf-tests.yml
@@ -1,7 +1,7 @@
 name: Run curieconf Python tests
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "curiefense/curieconf/**"
       - ".github/workflows/run-curieconf-tests.yml"

--- a/.github/workflows/upload-test-results.yml
+++ b/.github/workflows/upload-test-results.yml
@@ -1,0 +1,68 @@
+name: Upload test results (Python ${{ matrix.python-version }})
+
+on:
+  workflow_run:
+    workflows:
+      - "Run e2e tests on docker-compose"
+      - "Run e2e tests on Helm v2"
+      - "Run e2e tests on minikube"
+      - "Run e2e tests on minikube with fluentd"
+      - "Run curieconf Python tests"
+    types:
+      - completed
+
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: >
+       github.event.workflow_run.conclusion != 'skipped' && (
+          github.event.sender.login == 'dependabot[bot]' ||
+          github.event.workflow_run.head_repository.full_name != github.repository
+       )
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+             var fs = require('fs');
+             var path = require('path');
+             var artifacts_path = path.join('${{github.workspace}}', 'artifacts')
+             fs.mkdirSync(artifacts_path, { recursive: true })
+
+             var artifacts = await github.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: ${{ github.event.workflow_run.id }},
+             });
+
+             for (const artifact of artifacts.data.artifacts) {
+                var download = await github.actions.downloadArtifact({
+                   owner: context.repo.owner,
+                   repo: context.repo.repo,
+                   artifact_id: artifact.id,
+                   archive_format: 'zip',
+                });
+                var artifact_path = path.join(artifacts_path, `${artifact.name}.zip`)
+                fs.writeFileSync(artifact_path, Buffer.from(download.data));
+                console.log(`Downloaded ${artifact_path}`);
+             }
+      - name: Extract Artifacts
+        run: |
+           for file in artifacts/*.zip
+           do
+             if [ -f "$file" ]
+             then
+               dir="${file/%.zip/}"
+               mkdir -p "$dir"
+               unzip -d "$dir" "$file"
+             fi
+           done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          files: "artifacts/*/**/*.xml"

--- a/deploy/deploy-ci.sh
+++ b/deploy/deploy-ci.sh
@@ -51,12 +51,14 @@ kubectl patch -n istio-system deployment istio-pilot --patch '{"spec": {"templat
 sleep 5
 popd || exit
 
+PARAMS=()
+
 if [ -n "$USE_FLUENTD" ]; then
-    EXTRA_VALUES="${EXTRA_VALUES} -f curiefense/use-es-fluentd.yaml"
+    PARAMS+=("-f" "curiefense/use-es-fluentd.yaml")
 fi
 
 pushd deploy/curiefense-helm || exit
-./deploy.sh -f curiefense/use-local-bucket.yaml -f curiefense/e2e-ci.yaml "$EXTRA_VALUES"
+./deploy.sh -f curiefense/use-local-bucket.yaml -f curiefense/e2e-ci.yaml "${PARAMS[@]}" "$@"
 
 # Expose services
 # No need to pass the namespace as it's already


### PR DESCRIPTION
Use pull_request instead of pull_request_target:

* allows actually testing changes to the testing infra
* avoid exposing build secrets or providing code from unmerged PR with write-access to the repository

Test results from `pull_request_target` should be disregarded, as they do not reflect the state of the repository after merging this.

Signed-off-by: Xavier <xavier@reblaze.com>