### PR TITLE
build-docker-images.sh: actually use a temporary file

### DIFF
--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -9,7 +9,6 @@ cd "${0%/*}" || exit 1
 # To specify a different repo, set `REPO=my.repo.tld`
 
 REPO=${REPO:-curiefense}
-BUILD_OPT=${BUILD_OPT:-}
 
 declare -A status
 
@@ -42,7 +41,7 @@ do
         # a temporary file is needed on macos -- docker complains otherwise
         TMPFILE=$(mktemp)
         tar -czhf "$TMPFILE" -C "$image" .
-        if docker build -t "$IMG:$DOCKER_TAG" ${BUILD_OPT} - < "$TMPFILE"; then
+        if docker build -t "$IMG:$DOCKER_TAG" "$@" - < "$TMPFILE"; then
             STB="ok"
             if [ -n "$PUSH" ]; then
                 if docker push "$IMG:$DOCKER_TAG"; then

--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -40,7 +40,7 @@ do
         echo "=================== $IMG:$DOCKER_TAG ====================="
         # shellcheck disable=SC2086
         # a temporary file is needed on macos -- docker complains otherwise
-        TMPFILE=(mktemp)
+        TMPFILE=$(mktemp)
         tar -czhf "$TMPFILE" -C "$image" .
         if docker build -t "$IMG:$DOCKER_TAG" ${BUILD_OPT} - < "$TMPFILE"; then
             STB="ok"
@@ -59,6 +59,7 @@ do
             STP="SKIP"
             GLOBALSTATUS=1
         fi
+        rm "$TMPFILE"
         status[$image]="build=$STB  push=$STP"
 done
 


### PR DESCRIPTION
* actually use a temporary file, instead of a file called mktemp
* fix a shellshock error by removing the (unused) `BUILD_OPT` environment variable. Scripts arguments can be used instead.
Signed-off-by: Xavier <xavier@reblaze.com>