### PR TITLE
UI Toast messages changes according to UX Audit

### DIFF
--- a/curiefense/ui/package-lock.json
+++ b/curiefense/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2359,6 +2359,17 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/jsdom": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.10.tgz",
+      "integrity": "sha512-q3aIjp3ehhVSXSbvNyuireAfvU2umRiZ2aLumyeZewCnoNaokrRDdTu5IvaeE9pzNtWHXrUnM9lb22Vl3W08EA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -2420,6 +2431,12 @@
       "integrity": "sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA=",
       "dev": true
     },
+    "@types/parse5": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.0.tgz",
+      "integrity": "sha512-oPwPSj4a1wu9rsXTEGIJz91ISU725t0BmSnUhb57sI+M8XEmvUop84lzuiYdq0Y5M6xLY8DBPg0C2xEQKLyvBA==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
@@ -2458,6 +2475,12 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+      "dev": true
     },
     "@types/unist": {
       "version": "2.0.3",
@@ -4916,9 +4939,9 @@
       "integrity": "sha512-e14EF+3VSZ488yL/lJH0tR8mFWiEQVCMi/BQUMi2TGMBOk+zrDg4wryuwm/+dRSHJw0gMawp2tsW7X1JYUCE3A=="
     },
     "bulma-toast": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bulma-toast/-/bulma-toast-2.2.0.tgz",
-      "integrity": "sha512-vByq7Vo13ATS2/pjNeiX8zPQ86EnaGBqKYRwxM0gGiycJwleqoqHXDE6DxKEmULJzw7MQzHsgs7uz8o1FaTiGg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bulma-toast/-/bulma-toast-2.3.0.tgz",
+      "integrity": "sha512-HfMITkQv4GnrrvwMnpxtNlfdQcmVdl09wGqboqMzLuRWSDDM9EBghfuAeh6jPCKJpFvAeadw7N12XRY1AAJgyw=="
     },
     "bytes": {
       "version": "3.1.0",

--- a/curiefense/ui/package.json
+++ b/curiefense/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -19,7 +19,7 @@
     "axios": ">=0.21.1",
     "bootstrap": "^4.6.0",
     "bulma": "^0.9.2",
-    "bulma-toast": "^2.2.0",
+    "bulma-toast": "^2.3.0",
     "core-js": "^3.8.3",
     "jsoneditor": "^9.1.9",
     "lodash": "^4.17.20",
@@ -38,6 +38,7 @@
     "@testing-library/jest-dom": "^5.11.5",
     "@types/ip6addr": "^0.2.1",
     "@types/jest": "^26.0.20",
+    "@types/jsdom": "^16.2.10",
     "@types/jsoneditor": "^8.6.0",
     "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
@@ -72,8 +73,8 @@
     "typescript": "^3.9.7",
     "vue-jest": "^3.0.7",
     "vue-template-compiler": "^2.6.12",
-    "y18n": ">=4.0.1",
-    "webpack": "^4.44.2"
+    "webpack": "^4.44.2",
+    "y18n": ">=4.0.1"
   },
   "husky": {
     "hooks": {

--- a/curiefense/ui/src/assets/DatasetsUtils.ts
+++ b/curiefense/ui/src/assets/DatasetsUtils.ts
@@ -32,12 +32,19 @@ const titles: { [key: string]: string } = {
   'args-entry': 'Argument',
   'attrs-entry': 'Attribute',
   'aclpolicies': 'ACL Policies',
+  'aclpolicies-singular': 'ACL Policy',
   'ratelimits': 'Rate Limits',
+  'ratelimits-singular': 'Rate Limit',
   'urlmaps': 'URL Maps',
+  'urlmaps-singular': 'URL Map',
   'wafpolicies': 'WAF Policies',
-  'wafrules': 'WAF Signatures',
+  'wafpolicies-singular': 'WAF Policy',
+  'wafrules': 'WAF Rules',
+  'wafrules-singular': 'WAF Rule',
   'tagrules': 'Tag Rules',
+  'tagrules-singular': 'Tag Rule',
   'flowcontrol': 'Flow Control',
+  'flowcontrol-singular': 'Flow Control',
 }
 
 const limitOptionsTypes = {

--- a/curiefense/ui/src/assets/RequestsUtils.ts
+++ b/curiefense/ui/src/assets/RequestsUtils.ts
@@ -16,7 +16,7 @@ const axiosMethodsMap: Record<MethodNames, Function> = {
 }
 
 const processRequest = (methodName: MethodNames, apiUrl: string, data: any, config: AxiosRequestConfig,
-                        successMessage: string, failureMessage: string) => {
+                        successMessage: string, failureMessage: string, undoFunction: () => any) => {
   // Get correct axios method
   if (!methodName) {
     methodName = 'GET'
@@ -48,13 +48,13 @@ const processRequest = (methodName: MethodNames, apiUrl: string, data: any, conf
   request = request.then((response: AxiosResponse) => {
     // Toast message
     if (successMessage) {
-      Utils.successToast(successMessage)
+      Utils.toast(successMessage, 'is-success', undoFunction)
     }
     return response
   }).catch((error: Error) => {
     // Toast message
     if (failureMessage) {
-      Utils.failureToast(failureMessage)
+      Utils.toast(failureMessage, 'is-danger', undoFunction)
     }
     throw error
   })
@@ -62,9 +62,9 @@ const processRequest = (methodName: MethodNames, apiUrl: string, data: any, conf
 }
 
 const sendRequest = (methodName: MethodNames, urlTail: string, data?: any, config?: AxiosRequestConfig,
-                     successMessage?: string, failureMessage?: string) => {
+                     successMessage?: string, failureMessage?: string, undoFunction?: () => any) => {
   const apiUrl = `${confAPIRoot}/${confAPIVersion}/${urlTail}`
-  return processRequest(methodName, apiUrl, data, config, successMessage, failureMessage)
+  return processRequest(methodName, apiUrl, data, config, successMessage, failureMessage, undoFunction)
 }
 
 export default {

--- a/curiefense/ui/src/assets/Utils.ts
+++ b/curiefense/ui/src/assets/Utils.ts
@@ -70,27 +70,51 @@ const downloadFile = (fileName: string, fileType: string, data: any) => {
   link.click()
 }
 
-// Displays a toast message at the bottom left corner of the page
-const toast = (message: string, type: ToastType) => {
+// Default values for toast messages
+bulmaToast.setDefaults({
+  position: 'bottom-left',
+  closeOnClick: false,
+  dismissible: true,
+  duration: 10000,
+  opacity: 0.9,
+})
+
+// Displays a toast message
+const toast = (message: string | HTMLElement, type: ToastType, undoFunction?: () => any) => {
+  let element
+  if (undoFunction) {
+    element = buildToastUndoElement(message, undoFunction)
+  } else {
+    element = message
+  }
   bulmaToast.toast({
-    message: message,
-    type: <ToastType>`is-light ${type}`,
-    position: 'bottom-left',
-    closeOnClick: true,
-    pauseOnHover: true,
-    duration: 3000,
-    opacity: 0.8,
+    message: element,
+    type: type,
   })
 }
 
-// Displays the default toast with a success color
-const successToast = (message: string) => {
-  toast(message, 'is-success')
-}
-
-// Displays the default toast with a failure color
-const failureToast = (message: string) => {
-  toast(message, 'is-danger')
+// Builds the UI element with undo functionality for the toast messages
+const buildToastUndoElement = (message: string | HTMLElement, undoFunction: () => any) => {
+  const element = document.createElement('div')
+  let textElement
+  if (typeof message === 'string') {
+    textElement = document.createElement('span')
+    textElement.innerText = message
+  } else {
+    textElement = message
+  }
+  element.appendChild(textElement)
+  const undoInfoPrefixElement = document.createElement('span')
+  undoInfoPrefixElement.innerText = '\nTo undo this action, click '
+  const undoElement = document.createElement('a')
+  undoElement.onclick = undoFunction
+  undoElement.innerText = 'here'
+  const undoInfoSuffixElement = document.createElement('span')
+  undoInfoSuffixElement.innerText = '.'
+  element.appendChild(undoInfoPrefixElement)
+  element.appendChild(undoElement)
+  element.appendChild(undoInfoSuffixElement)
+  return element
 }
 
 export default {
@@ -100,6 +124,4 @@ export default {
   generateUniqueEntityName,
   downloadFile,
   toast,
-  successToast,
-  failureToast,
 }

--- a/curiefense/ui/src/components/AutocompleteInput.vue
+++ b/curiefense/ui/src/components/AutocompleteInput.vue
@@ -192,8 +192,10 @@ export default (Vue as VueConstructor<Vue & {
         if (!this.currentValue.length) {
           return
         }
-        Utils.failureToast(
-            `Selected tag [${this.currentValue}] is invalid! Tags must be at least three characters long.`,
+        Utils.toast(
+            `Selected tag "${this.currentValue}" is invalid!\n` +
+            `Tags must be at least ${this.minimumValueLength} characters long.`,
+            'is-danger',
         )
         this.currentValue = ''
       } else {

--- a/curiefense/ui/src/components/__tests__/AutocompleteInput.spec.ts
+++ b/curiefense/ui/src/components/__tests__/AutocompleteInput.spec.ts
@@ -371,14 +371,16 @@ describe('AutocompleteInput.vue', () => {
 
     test('should display a failure toast after selecting' +
       'input value when input is shorter than the minimumValueLength prop', async () => {
+      const minLength = 3
       const selectedValue = 't'
-      const failureMessage = `Selected tag [${selectedValue}] is invalid! Tags must be at least three characters long.`
+      const failureMessage = `Selected tag "${selectedValue}" is invalid!\n` +
+        `Tags must be at least ${minLength} characters long.`
       const failureMessageClass = 'is-danger'
       const toastOutput: Options[] = []
       jest.spyOn(bulmaToast, 'toast').mockImplementation((output: Options) => {
         toastOutput.push(output)
       })
-      wrapper.setProps({minimumValueLength: 3})
+      wrapper.setProps({minimumValueLength: minLength})
       await Vue.nextTick();
       (input.element as HTMLInputElement).value = selectedValue
       input.trigger('input')

--- a/curiefense/ui/src/views/DBEditor.vue
+++ b/curiefense/ui/src/views/DBEditor.vue
@@ -363,20 +363,9 @@ export default Vue.extend({
       this.setLoadingDocStatus(false)
     },
 
-    saveDatabase(database: string, data: { [key: string]: any }) {
-      if (!data) {
-        data = {key: {}}
-      }
-
-      return RequestsUtils.sendRequest('PUT',
-          `db/${database}/`,
-          data, null,
-          `Database [${database}] saved!`,
-          `Failed saving database [${database}]!`)
-    },
-
     switchDatabase() {
       this.loadDatabase(this.selectedDatabase)
+      Utils.toast(`Switched to database "${this.selectedDatabase}".`, 'is-info')
     },
 
     async deleteDatabase(database?: string, disableAnnouncementMessages?: boolean) {
@@ -391,8 +380,8 @@ export default Vue.extend({
       let successMessage
       let failureMessage
       if (!disableAnnouncementMessages) {
-        successMessage = `Database [${database}] deleted!`
-        failureMessage = `Failed deleting database [${database}]!`
+        successMessage = `Database "${database}" was deleted.`
+        failureMessage = `Failed while attempting to delete database "${database}".`
       }
       await RequestsUtils.sendRequest('DELETE', `db/${database}/`, null, null, successMessage, failureMessage)
       if (!this.databases.includes(this.selectedDatabase)) {
@@ -406,7 +395,14 @@ export default Vue.extend({
       if (!newDatabase) {
         newDatabase = Utils.generateUniqueEntityName('new database', this.databases)
       }
-      await this.saveDatabase(newDatabase, data).then(() => {
+      if (!data) {
+        data = {key: {}}
+      }
+      await RequestsUtils.sendRequest('PUT',
+          `db/${newDatabase}/`,
+          data, null,
+          `Database "${newDatabase}" was saved`,
+          `Failed while attempting to create the new database.`).then(() => {
         this.loadDatabase(newDatabase)
         this.databases.unshift(newDatabase)
       })
@@ -444,12 +440,13 @@ export default Vue.extend({
           `db/${database}/k/${key}/`,
           parsedDoc,
           null,
-          `Key [${key}] in database [${database}] saved!`,
-          `Failed saving key [${key}] in database [${database}]!`)
+          `Key "${key}" in database "${database}" was saved.`,
+          `Failed while attempting to save key "${key}" in database "${database}".`)
     },
 
     switchKey() {
       this.loadKey(this.selectedKey)
+      Utils.toast(`Switched to key "${this.selectedKey}".`, 'is-info')
     },
 
     async deleteKey(key?: string, disableAnnouncementMessages?: boolean) {
@@ -465,8 +462,8 @@ export default Vue.extend({
       let successMessage
       let failureMessage
       if (!disableAnnouncementMessages) {
-        successMessage = `Key [${key}] in database [${database}] deleted!`
-        failureMessage = `Failed deleting key [${key}] in database [${database}]!`
+        successMessage = `Key "${key}" in database "${database}" was deleted.`
+        failureMessage = `Failed while attempting to delete key "${key}" in database "${database}".`
       }
       await RequestsUtils.sendRequest('DELETE', `db/${database}/k/${key}/`, null, null, successMessage, failureMessage)
       if (!this.keys.includes(this.selectedKey)) {

--- a/curiefense/ui/src/views/DocumentSearch.vue
+++ b/curiefense/ui/src/views/DocumentSearch.vue
@@ -145,6 +145,7 @@ import RequestsUtils from '@/assets/RequestsUtils.ts'
 import Vue, {VueConstructor} from 'vue'
 import {Document, DocumentType, URLMapEntryMatch} from '@/types'
 import DatasetsUtils from '@/assets/DatasetsUtils'
+import Utils from '@/assets/Utils'
 
 type SearchDocument = Document & {
   docType: DocumentType
@@ -187,7 +188,7 @@ export default Vue.extend({
       'aclpolicies': {
         component: ACLEditor,
         title: titles['aclpolicies'],
-        fields: 'id, name, allow, allow_bot, deny_bot, bypass, deny, enforce_deny',
+        fields: 'id, name, allow, allow_bot, deny_bot, bypass, deny, force_deny',
       },
       'flowcontrol': {
         component: FlowControlEditor,
@@ -477,6 +478,7 @@ export default Vue.extend({
 
     async switchBranch() {
       await this.loadDocs()
+      Utils.toast(`Switched to branch ${this.selectedBranch}.`, 'is-info')
     },
 
     goToDocument(doc: SearchDocument) {

--- a/curiefense/ui/src/views/Publish.vue
+++ b/curiefense/ui/src/views/Publish.vue
@@ -199,13 +199,18 @@ export default Vue.extend({
       return classNames.join(' ')
     },
 
-    switchBranch() {
-      this.publishMode = false
+    loadBranchLogs() {
       const selectedBranch = _.find(this.configs, (conf) => {
         return conf.id === this.selectedBranchName
       })
       this.gitLog = selectedBranch.logs
       this.selectedCommit = this.gitLog[0]?.version || null
+    },
+
+    switchBranch() {
+      this.loadBranchLogs()
+      this.publishMode = false
+      Utils.toast(`Switched to branch "${this.selectedBranchName}".`, 'is-info')
       this.setDefaultBuckets()
     },
 
@@ -247,7 +252,8 @@ export default Vue.extend({
         this.configs = response.data
         // pick first branch name as selected
         this.selectedBranchName = this.branchNames[0]
-        this.switchBranch()
+        this.loadBranchLogs()
+        this.setDefaultBuckets()
       })
     },
 
@@ -267,15 +273,24 @@ export default Vue.extend({
       }).catch((error: Error) => {
         console.error(error)
         this.isPublishLoading = false
-        Utils.failureToast(`Failed publishing branch ${this.selectedBranchName} version ${this.selectedCommit}!`)
+        Utils.toast(
+            `Failed while attempting to publish branch "${this.selectedBranchName}" version "${this.selectedCommit}".`,
+            'is-danger',
+        )
       })
     },
 
     parsePublishResults(data: any) {
       if (data.ok) {
-        Utils.successToast(`Published branch ${this.selectedBranchName} version ${this.selectedCommit} successfully!`)
+        Utils.toast(
+            `Branch "${this.selectedBranchName}" was published with version "${this.selectedCommit}".`,
+            'is-success',
+        )
       } else {
-        Utils.failureToast(`Failed publishing branch ${this.selectedBranchName} version ${this.selectedCommit}!`)
+        Utils.toast(
+            `Failed while attempting to publish branch "${this.selectedBranchName}" version "${this.selectedCommit}".`,
+            'is-danger',
+        )
       }
       _.each(data.status, (responseStatus) => {
         const index = _.findIndex(this.publishedBuckets, (entry) => {

--- a/curiefense/ui/src/views/VersionControl.vue
+++ b/curiefense/ui/src/views/VersionControl.vue
@@ -273,6 +273,7 @@ export default Vue.extend({
 
     async switchBranch() {
       this.resetGitLog()
+      Utils.toast(`Switched to branch "${this.selectedBranch}".`, 'is-info')
       this.forkBranchInputOpen = false
       this.deleteBranchInputOpen = false
       await this.loadSelectedBranchData()
@@ -295,15 +296,15 @@ export default Vue.extend({
       const urlTrail = `configs/${branch}/v/${versionId}/`
 
       await RequestsUtils.sendRequest('PUT', `${urlTrail}revert/`, null, null,
-          `Branch [${branch}] restored to version [${versionId}]!`,
-          `Failed restoring branch [${branch}] to version [${versionId}]!`)
+          `Branch "${branch}" was restored to version "${versionId}".`,
+          `Failed while attempting to restore branch "${branch}" to version "${versionId}".`)
       await this.loadGitLog()
     },
 
     deleteBranch() {
       RequestsUtils.sendRequest('DELETE', `configs/${this.selectedBranch}/`, null, null,
-          `Branch [${this.selectedBranch}] deleted successfully!`,
-          `Failed deleting branch [${this.selectedBranch}]!`,
+          `Branch ${this.selectedBranch} was deleted.`,
+          `Failed while attempting to delete branch "${this.selectedBranch}".`,
       ).then(() => {
         this.loadConfigs()
         this.toggleBranchDelete()
@@ -319,8 +320,8 @@ export default Vue.extend({
             'id': 'string',
             'description': 'string',
           }, null,
-          `Branch [${this.selectedBranch}] forked to [${this.forkBranchName}] successfully!`,
-          `Failed forking branch [${this.selectedBranch}] to [${this.forkBranchName}]!`,
+          `Branch "${this.selectedBranch}" was forked to "${this.forkBranchName}".`,
+          `Failed while attempting to fork branch "${this.selectedBranch}" to "${this.forkBranchName}".`,
       ).then(() => {
         this.loadConfigs(newBranchName)
         this.toggleBranchFork()

--- a/curiefense/ui/src/views/__tests__/Publish.spec.ts
+++ b/curiefense/ui/src/views/__tests__/Publish.spec.ts
@@ -430,7 +430,7 @@ describe('Publish.vue', () => {
         return Promise.resolve({data: response})
       })
       successMessage =
-        `Published branch ${publishInfoData.buckets[0].name} version ${gitData[0].logs[0].version} successfully!`
+        `Branch "${publishInfoData.buckets[0].name}" was published with version "${gitData[0].logs[0].version}".`
       successMessageClass = 'is-success'
       toastOutput = []
       jest.spyOn(bulmaToast, 'toast').mockImplementation((output: Options) => {
@@ -490,8 +490,8 @@ describe('Publish.vue', () => {
       jest.spyOn(axios, 'put').mockImplementation(() => {
         return Promise.resolve({data: response})
       })
-      failureMessage =
-        `Failed publishing branch ${publishInfoData.buckets[0].name} version ${gitData[0].logs[0].version}!`
+      // eslint-disable-next-line max-len
+      failureMessage = `Failed while attempting to publish branch "${publishInfoData.buckets[0].name}" version "${gitData[0].logs[0].version}".`
       failureMessageClass = 'is-danger'
       toastOutput = []
       jest.spyOn(bulmaToast, 'toast').mockImplementation((output: Options) => {
@@ -547,8 +547,8 @@ describe('Publish.vue', () => {
       const mockedError = (output: string) => consoleOutput.push(output)
       consoleOutput = []
       console.error = mockedError
-      failureMessage =
-        `Failed publishing branch ${publishInfoData.buckets[0].name} version ${gitData[0].logs[0].version}!`
+      // eslint-disable-next-line max-len
+      failureMessage = `Failed while attempting to publish branch "${publishInfoData.buckets[0].name}" version "${gitData[0].logs[0].version}".`
       failureMessageClass = 'is-danger'
       toastOutput = []
       jest.spyOn(bulmaToast, 'toast').mockImplementation((output: Options) => {


### PR DESCRIPTION
* Add default settings to bulma toast - Closes #229
* Add toast message when the user switches between branches, document types, documents, databases, or keys
* Add infrastructure for undoing actions through toast messages
* Extend automatic dismissal of toast messages to better the user experience by enabling them to dismiss the messages at their own pace
* Improve contrast of toast messages to improve accessibility
* Improve Policies & Rules messages to be more informative
* Fix bug which caused ACLs not to be displayed in Policies & Rules search page - Closes #309
* Closes #261

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>