### PR TITLE
Mark all outputs as deprecated

### DIFF
--- a/curiefense/curielogger/pkg/outputs/elasticsearch.go
+++ b/curiefense/curielogger/pkg/outputs/elasticsearch.go
@@ -147,6 +147,7 @@ func (es *ElasticSearch) ConfigureKibana() {
 }
 
 func (es *ElasticSearch) ConfigureEs() {
+	log.Warn("The Elasticsearch output is deprecated and will be removed in the 1.5.0 release. More on the reasoning and discussion here: https://github.com/curiefense/curiefense/issues/317")
 	var res *esapi.Response
 	var err error
 	for i := 0; i < 60; i++ {

--- a/curiefense/curielogger/pkg/outputs/fluentd.go
+++ b/curiefense/curielogger/pkg/outputs/fluentd.go
@@ -2,10 +2,11 @@ package outputs
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"net/http"
 	neturl "net/url"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -18,7 +19,7 @@ type FluentD struct {
 
 func NewFluentD(v *viper.Viper) *FluentD {
 	log.Info(`initialized fluentd`)
-	log.Warn(`fluentd driver will be deprecated in next release please use the stdout driver`)
+	log.Warn("The FluentD output is deprecated and will be removed in the 1.5.0 release. More on the reasoning and discussion here: https://github.com/curiefense/curiefense/issues/317")
 	return &FluentD{url: fmt.Sprintf("%scuriefense.log", v.GetString(CURIELOGGER_FLUENTD_URL))}
 }
 

--- a/curiefense/curielogger/pkg/outputs/logstash.go
+++ b/curiefense/curielogger/pkg/outputs/logstash.go
@@ -2,9 +2,10 @@ package outputs
 
 import (
 	"bytes"
+	"net/http"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"net/http"
 )
 
 const (
@@ -23,7 +24,7 @@ type LogstashConfig struct {
 
 func NewLogstash(v *viper.Viper, cfg LogstashConfig) *Logstash {
 	log.Info(`initialized logstash`)
-	log.Warn(`logstash driver will be deprecated in next release please use the stdout driver`)
+	log.Warn("The Logstash output is deprecated and will be removed in the 1.5.0 release. More on the reasoning and discussion here: https://github.com/curiefense/curiefense/issues/317")
 	url := v.GetString(CURIELOGGER_OUTPUTS_LOGSTASH_URL)
 	if url == `` {
 		url = cfg.Url


### PR DESCRIPTION
As part of #317 all outputs will be deprecated and the default one will be the stdout output.

related to #317

Signed-off-by: Flavio Percoco <flavio@reblaze.com>