### PR TITLE
[docker-compose] Fix curieproxy metrics scrape

### DIFF
--- a/curiefense/images/prometheus/prometheus.yml
+++ b/curiefense/images/prometheus/prometheus.yml
@@ -8,11 +8,9 @@ scrape_configs:
       - targets: ['localhost:9090']
   - job_name: 'envoy_scrape'
     scrape_interval: 5s
-    metrics_path: /stats
-    params:
-      format: ['prometheus']
+    metrics_path: /stats/prometheus
     static_configs:
-      - targets: ['curiefense:8001']
+      - targets: ['curieproxy:8001']
   - job_name: 'curiefense'
     scrape_interval: 5s
     static_configs:


### PR DESCRIPTION
Hello,

While going through the Getting started with docker-compose, I noticed that hostname of scraping target for Curiefense proxy was invalid, so here is a PR addressing it.

I also updated path configuration to match Envoy Prometheus URL, and removed unneeded `format` parameter.