### PR TITLE
[istio] bump 1.9.2 -> 1.9.3

### DIFF
--- a/curiefense/images/curieproxy-istio/Dockerfile
+++ b/curiefense/images/curieproxy-istio/Dockerfile
@@ -1,5 +1,5 @@
-FROM curiefense/envoy-istio-cf:aad1978ca8a4af4a3aa2704a54d1d076d9271697 AS envoy-istio-cf
-FROM docker.io/istio/proxyv2:1.9.2
+FROM curiefense/envoy-istio-cf:1fc81107d58c138eba288f3d8b567bbca4b6423f AS envoy-istio-cf
+FROM docker.io/istio/proxyv2:1.9.3
 
 RUN apt-get update && \
     apt-get -yq --no-install-recommends install jq luarocks libpcre2-dev libgeoip-dev python dumb-init gcc g++ make unzip libhyperscan4 libhyperscan-dev && \

--- a/deploy/istio-helm/charts/base/Chart.yaml
+++ b/deploy/istio-helm/charts/base/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: base
-version: 1.9.2
+version: 1.9.3
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio cluster resources and CRDs
 keywords:

--- a/deploy/istio-helm/charts/gateways/istio-egress/Chart.yaml
+++ b/deploy/istio-helm/charts/gateways/istio-egress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio-egress
-version: 1.9.2
+version: 1.9.3
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio gateways
 keywords:

--- a/deploy/istio-helm/charts/gateways/istio-egress/values.yaml
+++ b/deploy/istio-helm/charts/gateways/istio-egress/values.yaml
@@ -168,7 +168,7 @@ global:
   hub: docker.io/istio
 
   # Default tag for Istio images.
-  tag: 1.9.2
+  tag: 1.9.3
 
   # Specify image pull policy if default behavior isn't desired.
   # Default behavior: latest images will be Always else IfNotPresent.

--- a/deploy/istio-helm/charts/gateways/istio-ingress/Chart.yaml
+++ b/deploy/istio-helm/charts/gateways/istio-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio-ingress
-version: 1.9.2
+version: 1.9.3
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio gateways
 keywords:

--- a/deploy/istio-helm/charts/gateways/istio-ingress/values.yaml
+++ b/deploy/istio-helm/charts/gateways/istio-ingress/values.yaml
@@ -54,7 +54,7 @@ gateways:
         memory: 128Mi
       limits:
         cpu: 2000m
-        memory: 1024Mi
+        memory: 2048Mi
 
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
@@ -237,6 +237,8 @@ global:
     gw_image: curiefense/curieproxy-istio
     curiesync_image: curiefense/curiesync
     curieconf_manifest_url: "s3://curiefense-test01/prod/manifest.json"
+    # allowed values: "s3", "gs", "local-bucket"
+    curiefense_bucket_type: "s3"
     # namespace where curiefense components are running (redis, curielogger)
     curiefense_namespace: "curiefense"
     # typically "redis.$curiefense_namespace", can be changed to use an external redis instance

--- a/deploy/istio-helm/charts/gateways/istio-ingress/values.yaml
+++ b/deploy/istio-helm/charts/gateways/istio-ingress/values.yaml
@@ -177,7 +177,7 @@ global:
   hub: docker.io/istio
 
   # Default tag for Istio images.
-  tag: 1.9.2
+  tag: 1.9.3
 
   # Specify image pull policy if default behavior isn't desired.
   # Default behavior: latest images will be Always else IfNotPresent.

--- a/deploy/istio-helm/charts/istio-control/istio-discovery/Chart.yaml
+++ b/deploy/istio-helm/charts/istio-control/istio-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio-discovery
-version: 1.9.2
+version: 1.9.3
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio control plane
 keywords:

--- a/deploy/istio-helm/charts/istio-control/istio-discovery/values.yaml
+++ b/deploy/istio-helm/charts/istio-control/istio-discovery/values.yaml
@@ -232,7 +232,7 @@ global:
   # Dev builds from prow are on gcr.io
   hub: docker.io/istio
   # Default tag for Istio images.
-  tag: 1.9.2
+  tag: 1.9.3
 
   # Specify image pull policy if default behavior isn't desired.
   # Default behavior: latest images will be Always else IfNotPresent.

--- a/deploy/istio-helm/use-gs.yaml
+++ b/deploy/istio-helm/use-gs.yaml
@@ -1,0 +1,8 @@
+---
+# use this file to override default values from ../values.yaml
+# ./deploy.sh -f chart/use-gs.yaml
+global:
+  proxy:
+    curieconf_manifest_url: "gs://curiefense-test-s3-replacement/prod/manifest.json"
+    curiefense_bucket_type: "gs"
+

--- a/deploy/istio-helm/use-local-bucket.yaml
+++ b/deploy/istio-helm/use-local-bucket.yaml
@@ -1,0 +1,7 @@
+---
+# use this file to override default values from ../values.yaml
+# ./deploy.sh -f curiefense/use-gs.yaml
+global:
+  proxy:
+    curieconf_manifest_url: 'file:///bucket/prod/manifest.json'
+    curiefense_bucket_type: 'local-bucket'

--- a/deploy/istio-helm/values-istio-ci.yaml
+++ b/deploy/istio-helm/values-istio-ci.yaml
@@ -1,0 +1,85 @@
+# This is used to generate istio.yaml for minimal, demo mode.
+# It is shipped with the release, used for bookinfo or quick installation of istio.
+# Includes components used in the demo, defaults to alpha3 rules.
+global:
+  imagePullPolicy: IfNotPresent
+
+  controlPlaneSecurityEnabled: false
+
+  proxy:
+    accessLogFile: "/dev/stdout"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+
+  disablePolicyChecks: false
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: false
+
+sidecarInjectorWebhook:
+  enabled: true
+  # If true, webhook or istioctl injector will rewrite PodSpec for liveness
+  # health check to redirect request to sidecar. This makes liveness check work
+  # even when mTLS is enabled.
+  rewriteAppHTTPProbe: true
+
+pilot:
+  autoscaleEnabled: false
+  traceSampling: 100.0
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+
+mixer:
+  policy:
+    enabled: true
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 100Mi
+
+  telemetry:
+    enabled: false
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+
+  adapters:
+    stdio:
+      enabled: true
+
+grafana:
+  enabled: false
+
+tracing:
+  enabled: false
+
+prometheus:
+  enabled: false
+
+kiali:
+  enabled: false
+
+gateways:
+  istio-ingressgateway:
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+
+  istio-egressgateway:
+    enabled: true
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi

--- a/deploy/istio-helm/values-istio-demo.yaml
+++ b/deploy/istio-helm/values-istio-demo.yaml
@@ -1,0 +1,81 @@
+# This is used to generate istio.yaml for minimal, demo mode.
+# It is shipped with the release, used for bookinfo or quick installation of istio.
+# Includes components used in the demo, defaults to alpha3 rules.
+global:
+  controlPlaneSecurityEnabled: false
+  
+  proxy:
+    accessLogFile: "/dev/stdout"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+
+  disablePolicyChecks: false
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: false
+
+sidecarInjectorWebhook:
+  enabled: true
+  # If true, webhook or istioctl injector will rewrite PodSpec for liveness
+  # health check to redirect request to sidecar. This makes liveness check work
+  # even when mTLS is enabled.
+  rewriteAppHTTPProbe: true
+
+pilot:
+  autoscaleEnabled: false
+  traceSampling: 100.0
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+
+mixer:
+  policy:
+    enabled: true
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 100Mi
+
+  telemetry:
+    enabled: true
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+ 
+  adapters:
+    stdio:
+      enabled: true
+ 
+grafana:
+  enabled: true
+
+tracing:
+  enabled: true
+
+kiali:
+  enabled: true
+  createDemoSecret: true
+
+gateways:
+  istio-ingressgateway:
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+
+  istio-egressgateway:
+    enabled: true
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi

--- a/deploy/istio-helm/values-istio-minimal.yaml
+++ b/deploy/istio-helm/values-istio-minimal.yaml
@@ -1,0 +1,49 @@
+#
+# Minimal Istio Configuration: https://istio.io/docs/setup/kubernetes/additional-setup/config-profiles/
+#
+pilot:
+  enabled: true
+  sidecar: false
+
+gateways:
+  enabled: false
+
+security:
+  enabled: false
+
+sidecarInjectorWebhook:
+  enabled: false
+
+galley:
+  enabled: false
+
+mixer:
+  policy:
+    enabled: false
+  telemetry:
+    enabled: false
+
+prometheus:
+  enabled: false
+
+
+# Common settings.
+global:
+
+  proxy:
+    # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument
+    # would be <host>:<port>).
+    # Disabled by default.
+    # The istio-statsd-prom-bridge is deprecated and should not be used moving forward.
+    envoyStatsd:
+      # If enabled is set to true, host and port must also be provided. Istio no longer provides a statsd collector.
+      enabled: false
+      host: # example: statsd-svc.istio-system
+      port: # example: 9125
+  
+  useMCP: false
+
+  mtls:
+    auto: false
+
+

--- a/deploy/istio-helm/values-istio-remote.yaml
+++ b/deploy/istio-helm/values-istio-remote.yaml
@@ -1,0 +1,37 @@
+gateways:
+  enabled: false
+
+galley:
+  enabled: false
+
+mixer:
+  policy:
+    enabled: false
+  telemetry:
+    enabled: false
+
+pilot:
+  enabled: false
+  configSource:
+    subscribedResources:
+
+security:
+  enabled: true
+  createMeshPolicy: false
+  selfSigned: false
+
+prometheus:
+  enabled: false
+
+global:
+  istioRemote: true
+
+  enableTracing: false
+
+  # Sets an identifier for the remote network to be used for Split Horizon EDS. The network will be sent
+  # to the Pilot when connected by the sidecar and will affect the results returned in EDS requests.
+  # Based on the network identifier Pilot will return all local endpoints + endpoints of gateways to
+  # other networks.
+  #
+  # Must match the names in the meshNetworks section in the Istio local.
+  network: ""

--- a/e2e/latency/ratings-virtualservice.yml
+++ b/e2e/latency/ratings-virtualservice.yml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: bookinfo-ratings
-  namespace: bookinfo
 spec:
   gateways:
   - bookinfo-gateway


### PR DESCRIPTION
Update istio to 1.9.3:

* update istio charts
* update curieproxy-istio docker image (`envoy` binary is built in https://github.com/curiefense/istio-proxy/commit/1fc81107d58c138eba288f3d8b567bbca4b6423f)

Fix issues:
* Increase memory limit for ingressgateway to 2Gi instead of 1Gi (value that was used before #311. When running latency tests, I see a max RAM usage of <1.5Gi)
* Fix the latency tests in `deploy-gke.sh`