### PR TITLE
Add feature to undo a version restoration through our git history component

### DIFF
--- a/curiefense/ui/package-lock.json
+++ b/curiefense/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/curiefense/ui/package-lock.json
+++ b/curiefense/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/curiefense/ui/package.json
+++ b/curiefense/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/curiefense/ui/package.json
+++ b/curiefense/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/curiefense/ui/src/components/GitHistory.vue
+++ b/curiefense/ui/src/components/GitHistory.vue
@@ -18,13 +18,25 @@
               <th class="is-size-7">Message</th>
               <th class="is-size-7">Author</th>
               <th class="is-size-7">Email</th>
-              <th class="is-size-7"></th>
+              <th class="is-size-7">
+                <p class="control has-text-centered" v-if="commitsRestorationLog.length > 0">
+                  <button class="button is-small undo-restore-button"
+                          @click="restoreVersionFromLog()"
+                          tabindex="1"
+                          title="Undo latest version restore">
+                    <span class="icon is-small">
+                      <i class="fas fa-history"></i>
+                    </span>
+                  </button>
+                </p>
+              </th>
             </tr>
             </thead>
             <tbody>
             <tr v-for="(commit, index) in commits" :key="commit.version"
                 @mouseleave="mouseLeave()"
-                @mouseover="mouseOver(index)">
+                @mouseover="mouseOver(index)"
+                class="version-row">
               <td class="is-size-7 is-vcentered py-3">{{ commit.date }}</td>
               <td class="is-size-7 is-vcentered py-3" :title="commit.version">
                 {{ commit.version.substr(0, 7) }}
@@ -40,9 +52,9 @@
               <td class="is-size-7 is-vcentered restore-cell">
                 <p class="control has-text-centered" v-if="commitOverIndex === index">
                   <button class="button is-small restore-button"
-                     @click="restoreVersion(commit)"
-                     tabindex="1"
-                     title="Restore version">
+                          @click="restoreVersion(commit, true)"
+                          tabindex="1"
+                          title="Restore version">
                     <span class="icon is-small">
                       <i class="fas fa-history"></i>
                     </span>
@@ -88,6 +100,7 @@ export default Vue.extend({
       expanded: false,
       init_max_rows: 5,
       commitOverIndex: null,
+      commitsRestorationLog: [] as Commit[],
     }
   },
 
@@ -101,9 +114,25 @@ export default Vue.extend({
     },
   },
 
+  watch: {
+    gitLog: function(newVal) {
+      if (!newVal.length) {
+        this.commitsRestorationLog = []
+      }
+    },
+  },
+
   methods: {
-    restoreVersion(commit: Commit) {
+    restoreVersion(commit: Commit, log?: boolean) {
+      if (log) {
+        this.commitsRestorationLog.push(this.commits[0])
+      }
       this.$emit('restore-version', commit)
+    },
+
+    restoreVersionFromLog() {
+      const commit = this.commitsRestorationLog.pop()
+      this.restoreVersion(commit, false)
     },
 
     mouseLeave() {

--- a/curiefense/ui/src/components/__tests__/GitHistory.spec.ts
+++ b/curiefense/ui/src/components/__tests__/GitHistory.spec.ts
@@ -1,10 +1,12 @@
 import GitHistory from '@/components/GitHistory.vue'
-import {describe, test, expect, beforeEach} from '@jest/globals'
+import {beforeEach, describe, expect, test} from '@jest/globals'
 import {mount, Wrapper} from '@vue/test-utils'
+import {Commit} from '@/types'
+import Vue from 'vue'
 
 describe('GitHistory.vue', () => {
   // Number of log items = 7
-  const gitLog = [
+  const initialGitLog = [
     {
       'version': '7dd9580c00bef1049ee9a531afb13db9ef3ee956',
       'date': '2020-11-10T15:49:17+02:00',
@@ -76,13 +78,34 @@ describe('GitHistory.vue', () => {
       'author': 'Curiefense API',
     },
   ]
+  let gitLog = initialGitLog
   const apiPath = '/conf/api/v1/configs/master/d/aclpolicies/e/__default__/v/'
   let wrapper: Wrapper<Vue>
   beforeEach(() => {
+    gitLog = initialGitLog
+    const newVersions = [
+      'b88b46ac16348d86e38cc1ba50686cde6a9c78c1',
+      '1a172f464b73d62ccbc0f545732dc527ec0125d4',
+      'a6f7a5d907fa0cd2340a393e3f57624d6c5ce1cf',
+      'b280dead30cb7cf9024493f4bc85d499dc3b67ed',
+    ]
+    const onRestoreVersion = (commit: Commit) => {
+      const newGitLog = JSON.parse(JSON.stringify(gitLog))
+      const newCommit = JSON.parse(JSON.stringify(commit))
+      newCommit.version = newVersions.pop()
+      newCommit.parents = [newGitLog[0].version]
+      newCommit.message = 'updated for tests'
+      newGitLog.unshift(newCommit)
+      wrapper.setProps({gitLog: newGitLog})
+      gitLog = newGitLog
+    }
     wrapper = mount(GitHistory, {
       propsData: {
         gitLog,
         apiPath,
+      },
+      listeners: {
+        'restore-version': onRestoreVersion,
       },
     })
   })
@@ -131,28 +154,108 @@ describe('GitHistory.vue', () => {
     })
 
     test('should render a single restore button when hovering over a row', async () => {
-      // 0 is the table header, 1 is our first data
-      const firstDataRow = wrapper.findAll('tr').at(1)
+      const firstDataRow = wrapper.findAll('.version-row').at(0)
       await firstDataRow.trigger('mouseover')
       expect(firstDataRow.findAll('.restore-button').length).toEqual(1)
     })
 
     test('should stop rendering the restore button when no longer hovering over a row', async () => {
-      // 0 is the table header, 1 is our first data
-      const firstDataRow = wrapper.findAll('tr').at(1)
+      const firstDataRow = wrapper.findAll('.version-row').at(0)
       await firstDataRow.trigger('mouseover')
       await firstDataRow.trigger('mouseleave')
       expect(firstDataRow.findAll('.restore-button').length).toEqual(0)
     })
 
     test('should emit a restore-version event when restore button is clicked', async () => {
-      // 0 is the table header, 1 is our first data
-      const firstDataRow = wrapper.findAll('tr').at(1)
+      const firstDataRow = wrapper.findAll('.version-row').at(0)
       await firstDataRow.trigger('mouseover')
       const restoreButton = firstDataRow.find('.restore-button')
       await restoreButton.trigger('click')
       expect(wrapper.emitted('restore-version')).toBeTruthy()
-      expect(wrapper.emitted('restore-version')[0]).toEqual([gitLog[0]])
+      expect(wrapper.emitted('restore-version')[0]).toEqual([gitLog[1]])
+    })
+  })
+
+  describe('undoing log version restoration', () => {
+    test('should not render undo button when no version has been restored yet', () => {
+      expect(wrapper.findAll('.undo-restore-button').length).toEqual(0)
+    })
+
+    describe('after a few versions had been restored', () => {
+      let timesRestored = 0
+      beforeEach(async () => {
+        timesRestored = 0
+        let dataRow = wrapper.findAll('.version-row').at(1)
+        await dataRow.trigger('mouseover')
+        let restoreButton = dataRow.find('.restore-button')
+        await restoreButton.trigger('click')
+        timesRestored++
+        await wrapper.vm.$forceUpdate()
+
+        // 2 + timesRestored = 3 = location 2 in the original gitLog
+        dataRow = wrapper.findAll('.version-row').at(2 + timesRestored)
+        await dataRow.trigger('mouseover')
+        restoreButton = dataRow.find('.restore-button')
+        await restoreButton.trigger('click')
+        timesRestored++
+        await wrapper.vm.$forceUpdate()
+      })
+
+      test('should render a single undo button', async () => {
+        expect(wrapper.findAll('.undo-restore-button').length).toEqual(1)
+      })
+
+      test('should stop rendering the undo version restore button when gitLog is set to an empty array', async () => {
+        wrapper.setProps({gitLog: []})
+        await Vue.nextTick()
+        expect(wrapper.findAll('.undo-restore-button').length).toEqual(0)
+      })
+
+      test('should emit a restore-version event with correct version when undo button is clicked', async () => {
+        const restoreButton = wrapper.find('.undo-restore-button')
+        await restoreButton.trigger('click')
+        timesRestored++
+        // 0 - current version after undo (undid restoration. Moved from version at 1, to version at 2)
+        // 1 - version after second restoration (restored from 5)
+        // 2 - version after first restoration (restored from 4)
+        // 3 - original version at the start of the tests
+        // 4 - original version in gitLog[1] (restored to 2)
+        // 5 - original version in gitLog[2] (restored to 1)
+        expect(wrapper.emitted('restore-version')).toBeTruthy()
+        expect(wrapper.emitted('restore-version')[timesRestored - 1]).toEqual([gitLog[2]])
+      })
+
+      test('should emit a restore-version events correctly when undo button is clicked multiple times', async () => {
+        const restoreButton = wrapper.find('.undo-restore-button')
+        await restoreButton.trigger('click')
+        timesRestored++
+        // 0 - current version after undo (undid restoration. Moved from version at 1, to version at 2)
+        // 1 - version after second restoration (restored from 5)
+        // 2 - version after first restoration (restored from 4)
+        // 3 - original version at the start of the tests
+        // 4 - original version in gitLog[1] (restored to 2)
+        // 5 - original version in gitLog[2] (restored to 1)
+        expect(wrapper.emitted('restore-version')).toBeTruthy()
+        expect(wrapper.emitted('restore-version')[timesRestored - 1]).toEqual([gitLog[2]])
+        await restoreButton.trigger('click')
+        timesRestored++
+        // 0 - current version after second undo (undid restoration. Moved from version at 3, to version at 4)
+        // 1 - current version after first undo (undid restoration. Moved from version at 2, to version at 3)
+        // 2 - version after second restoration (restored from 6)
+        // 3 - version after first restoration (restored from 5)
+        // 4 - original version at the start of the tests
+        // 5 - original version in gitLog[1] (restored to 3)
+        // 6 - original version in gitLog[2] (restored to 2)
+        expect(wrapper.emitted('restore-version')).toBeTruthy()
+        expect(wrapper.emitted('restore-version')[timesRestored - 1]).toEqual([gitLog[4]])
+      })
+
+      test('should stop rendering the undo version restore button when undid all known version restores', async () => {
+        const restoreButton = wrapper.find('.undo-restore-button')
+        await restoreButton.trigger('click')
+        await restoreButton.trigger('click')
+        expect(wrapper.findAll('.undo-restore-button').length).toEqual(0)
+      })
     })
   })
 })

--- a/curiefense/ui/src/views/DBEditor.vue
+++ b/curiefense/ui/src/views/DBEditor.vue
@@ -364,6 +364,7 @@ export default Vue.extend({
     },
 
     switchDatabase() {
+      this.resetGitLog()
       this.loadDatabase(this.selectedDatabase)
       Utils.toast(`Switched to database "${this.selectedDatabase}".`, 'is-info')
     },
@@ -445,6 +446,7 @@ export default Vue.extend({
     },
 
     switchKey() {
+      this.resetGitLog()
       this.loadKey(this.selectedKey)
       Utils.toast(`Switched to key "${this.selectedKey}".`, 'is-info')
     },
@@ -527,6 +529,10 @@ export default Vue.extend({
       }
       await this.loadGitLog()
       this.isSaveDocLoading = false
+    },
+
+    resetGitLog() {
+      this.gitLog = []
     },
 
     async loadGitLog() {

--- a/curiefense/ui/src/views/DocumentEditor.vue
+++ b/curiefense/ui/src/views/DocumentEditor.vue
@@ -147,9 +147,9 @@
 
       <hr/>
 
-      <div class="content document-editor-wrapper"
-           v-if="!loadingDocCounter && selectedBranch && selectedDocType && selectedDoc">
+      <div class="content document-editor-wrapper">
         <component
+            v-if="!loadingDocCounter && selectedBranch && selectedDocType && selectedDoc"
             :is="componentsMap[selectedDocType].component"
             :selectedBranch.sync="selectedBranch"
             :selectedDoc.sync="selectedDoc"
@@ -159,14 +159,14 @@
             ref="currentComponent">
         </component>
         <hr/>
-        <git-history v-if="selectedDocID"
+        <git-history v-show="selectedDocID"
                      :gitLog="gitLog"
                      :apiPath="gitAPIPath"
                      @restore-version="restoreGitVersion"></git-history>
       </div>
 
       <div class="content no-data-wrapper"
-           v-else>
+           v-if="loadingDocCounter || !selectedBranch || !selectedDocType || !selectedDoc">
         <div v-if="loadingDocCounter > 0">
           <button class="button is-outlined is-text is-small is-loading document-loading">
             Loading
@@ -485,6 +485,7 @@ export default Vue.extend({
 
     async switchDocID() {
       this.setLoadingDocStatus(true)
+      this.resetGitLog()
       this.loadGitLog()
       Utils.toast(
           `Switched to document "${(this.selectedDoc as BasicDocument).name}" with ID "${this.selectedDocID}".`,

--- a/curiefense/ui/src/views/VersionControl.vue
+++ b/curiefense/ui/src/views/VersionControl.vue
@@ -290,7 +290,6 @@ export default Vue.extend({
     },
 
     async restoreGitVersion(gitVersion: Commit) {
-      this.resetGitLog()
       const branch = this.selectedBranch
       const versionId = gitVersion.version
       const urlTrail = `configs/${branch}/v/${versionId}/`
@@ -302,18 +301,21 @@ export default Vue.extend({
     },
 
     deleteBranch() {
+      this.resetGitLog()
       RequestsUtils.sendRequest('DELETE', `configs/${this.selectedBranch}/`, null, null,
           `Branch ${this.selectedBranch} was deleted.`,
           `Failed while attempting to delete branch "${this.selectedBranch}".`,
       ).then(() => {
         this.loadConfigs()
         this.toggleBranchDelete()
+        this.loadGitLog()
       }).catch((error: Error) => {
         console.error(error)
       })
     },
 
     forkBranch() {
+      this.resetGitLog()
       const newBranchName = this.forkBranchName
       RequestsUtils.sendRequest('POST', `configs/${this.selectedBranch}/clone/${newBranchName}/`,
           {
@@ -325,6 +327,7 @@ export default Vue.extend({
       ).then(() => {
         this.loadConfigs(newBranchName)
         this.toggleBranchFork()
+        this.loadGitLog()
       }).catch((error: Error) => {
         console.error(error)
       })

--- a/curiefense/ui/src/views/__tests__/VersionControl.spec.ts
+++ b/curiefense/ui/src/views/__tests__/VersionControl.spec.ts
@@ -327,18 +327,21 @@ describe('VersionControl.vue', () => {
     expect(putSpy).toHaveBeenCalledWith(`/conf/api/v1/configs/master/v/${wantedVersion.version}/revert/`)
   })
 
-  test('should attempt to download branch when download button is clicked', async () => {
+  test('should attempt to download branch when download button is clicked', async (done) => {
     const wantedFileName = 'master'
     const wantedFileType = 'json'
     const wantedFileData = gitData[0]
     const downloadFileSpy = jest.spyOn(Utils, 'downloadFile')
     // force update because downloadFile is mocked after it is read to to be used as event handler
     await wrapper.vm.$forceUpdate()
-    await Vue.nextTick()
-    const downloadBranchButton = wrapper.find('.download-branch-button')
-    downloadBranchButton.trigger('click')
-    await Vue.nextTick()
-    expect(downloadFileSpy).toHaveBeenCalledWith(wantedFileName, wantedFileType, wantedFileData)
+    // allow all requests to finish
+    setImmediate(async () => {
+      const downloadBranchButton = wrapper.find('.download-branch-button')
+      downloadBranchButton.trigger('click')
+      await Vue.nextTick()
+      expect(downloadFileSpy).toHaveBeenCalledWith(wantedFileName, wantedFileType, wantedFileData)
+      done()
+    })
   })
 
   test('should not attempt to download branch when download button is clicked while loading is true', async () => {
@@ -429,19 +432,19 @@ describe('VersionControl.vue', () => {
       expect(postSpy).not.toHaveBeenCalled()
     })
 
-    test('should be hidden if forked successfully', async () => {
+    test('should be hidden if forked successfully', async (done) => {
       const newBranchName = 'new_branch'
       let forkBranchNameInput = wrapper.find('.fork-branch-input')
       const forkBranchSaveButton = wrapper.find('.fork-branch-confirm')
       forkBranchNameInput.setValue(newBranchName)
       await Vue.nextTick()
       forkBranchSaveButton.trigger('click')
-      // process click
-      await Vue.nextTick()
-      // process API (fake) return
-      await Vue.nextTick()
-      forkBranchNameInput = wrapper.find('.fork-branch-input')
-      expect(forkBranchNameInput.element).toBeUndefined()
+      // allow all requests to finish
+      setImmediate(() => {
+        forkBranchNameInput = wrapper.find('.fork-branch-input')
+        expect(forkBranchNameInput.element).toBeUndefined()
+        done()
+      })
     })
 
     test('should be visible if fork failed', async () => {
@@ -521,19 +524,19 @@ describe('VersionControl.vue', () => {
       expect(deleteSpy).not.toHaveBeenCalled()
     })
 
-    test('should be hidden if deleted successfully', async () => {
+    test('should be hidden if deleted successfully', async (done) => {
       const currentBranchName = (wrapper.vm as any).selectedBranch
       let deleteBranchNameInput = wrapper.find('.delete-branch-input')
       const deleteBranchSaveButton = wrapper.find('.delete-branch-confirm')
       deleteBranchNameInput.setValue(currentBranchName)
       await Vue.nextTick()
       deleteBranchSaveButton.trigger('click')
-      // process click
-      await Vue.nextTick()
-      // process API (fake) return
-      await Vue.nextTick()
-      deleteBranchNameInput = wrapper.find('.delete-branch-input')
-      expect(deleteBranchNameInput.element).toBeUndefined()
+      // allow all requests to finish
+      setImmediate(() => {
+        deleteBranchNameInput = wrapper.find('.delete-branch-input')
+        expect(deleteBranchNameInput.element).toBeUndefined()
+        done()
+      })
     })
 
     test('should be visible if delete failed', async () => {


### PR DESCRIPTION
* Add undo version restoration functionality
* Add undo button which appears when there is an active restoration history (in the same page)
* Add unit tests for the new undo version restoration feature
* Change DocumentEditor.vue to hide gitLog while loading document instead of remove it from the DOM and reload it
* Change any usage of GitHistory.vue to reset the git log when switching log source (switch branch, doctype, etc.)
Closes #298 

Blocked by https://github.com/curiefense/curiefense/pull/327 - To keep version history intact, this PR (UI version 1.3.4) will be created as a draft until PR327 is merged (UI version 1.3.3)


Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>