### PR TITLE
[uiserver] add options to configure links to kibana&grafana

### DIFF
--- a/curiefense/images/uiserver/init/start_nginx.sh
+++ b/curiefense/images/uiserver/init/start_nginx.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
+
+CURL="curl --silent --write-out %{http_code}\n -H Content-Type:application/json --output /dev/null"
+
+configure_links () {
+	URL="http://confserver/api/v1/db/system/k/links/"
+	DATA="{\"kibana_url\":\"$KIBANA_UI_URL\",\"grafana_url\":\"$GRAFANA_UI_URL\"}"
+	if $CURL "$URL" -X PUT -H 'Accept: application/json' --data-raw "$DATA"| grep -qv 200; then
+		sleep 5
+		configure_links
+	fi
+}
+
+# Configure links to kibana & grafana
+if [ -n "$GRAFANA_UI_URL" ] && [ -n "$KIBANA_UI_URL" ]; then
+	echo "Updating links in the curieconf database..."
+	configure_links
+	echo "Links successfully configured in the curieconf database."
+fi
+
+
+# Enable TLS if required secrets are present -- docker environments
 if [ -f /run/secrets/uisslcrt ]; then
 	sed -i 's/# TLS-DOCKERCOMPOSE //' /init/nginx.conf
 fi
 
+# Enable TLS if required secrets are present -- k8s environments
 if [ -f /run/secrets/uisslcrt/uisslcrt ]; then
 	sed -i 's/# TLS-K8S //' /init/nginx.conf
 fi

--- a/curiefense/ui/src/components/SideMenu.vue
+++ b/curiefense/ui/src/components/SideMenu.vue
@@ -118,7 +118,7 @@ export default Vue.extend({
   methods: {
     async loadLinksFromDB() {
       const systemDBData = (await RequestsUtils.sendRequest('GET', `db/system/`)).data
-      const kibanaURL = systemDBData?.links?.kibaba_url ? systemDBData.links.kibaba_url : this.defaultKibanaURL
+      const kibanaURL = systemDBData?.links?.kibana_url ? systemDBData.links.kibana_url : this.defaultKibanaURL
       const grafanaURL = systemDBData?.links?.grafana_url ? systemDBData.links.grafana_url : this.defaultGrafanaURL
       this.menuItems.analytics.kibana = {
         title: 'Access Log (ELK)',

--- a/curiefense/ui/src/components/__tests__/SideMenu.spec.ts
+++ b/curiefense/ui/src/components/__tests__/SideMenu.spec.ts
@@ -19,7 +19,7 @@ describe('SideMenu.vue', () => {
     grafanaURL = 'https://10.0.0.1:30300/'
     const dbData = {
       links: {
-        kibaba_url: kibanaURL,
+        kibana_url: kibanaURL,
         grafana_url: grafanaURL,
       },
     }


### PR DESCRIPTION
The UI server displays links to Kibana & Grafana on the left page of
every page. The target of these links are retrieved from the
configuration server, from the "links" document of the "system" database.

This commit makes it easier to configure the target of these links by
setting two environment variables, GRAFANA_UI_URL and KIBANA_UI_URL.

Signed-off-by: Xavier <xavier@reblaze.com>