### PR TITLE
[docker] improve handling of contrib scripts

### DIFF
--- a/curiefense/images/curielogger/Dockerfile
+++ b/curiefense/images/curielogger/Dockerfile
@@ -7,7 +7,7 @@ RUN go build -o build/curielogger ./cmd/grpc
 FROM alpine
 RUN apk update && apk add ca-certificates curl bash && rm -rf /var/cache/apk/*
 RUN mkdir -p /etc/curielogger/
-COPY contrib /etc/curielogger/contrib
+COPY contrib /contrib
 COPY --from=builder /app/build/curielogger /bin
 COPY --from=builder /app/curielogger.yml /etc/curielogger/
 ENTRYPOINT ["/bin/curielogger"]

--- a/curiefense/images/curielogger/Dockerfile
+++ b/curiefense/images/curielogger/Dockerfile
@@ -5,7 +5,7 @@ COPY curielogger .
 RUN go build -o build/curielogger ./cmd/grpc
 
 FROM alpine
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates curl bash && rm -rf /var/cache/apk/*
 RUN mkdir -p /etc/curielogger/
 COPY contrib /etc/curielogger/contrib
 COPY --from=builder /app/build/curielogger /bin


### PR DESCRIPTION
This PR improves the handling of ES configuration scripts in `contrib/`:
* Installs dependencies (curl & bash)
* Moves these files in the Docker image from `/etc/curielogger/contrib` to `/contrib`, so that a Secret or ConfigMap can be mounted over `/etc/curielogger` to deploy a configuration file.

Signed-off-by: Xavier <xavier@reblaze.com>