### PR TITLE
es6 init script: add knob to disable kibana initialization

### DIFF
--- a/contrib/curielogger/elk/6_x/es_config.sh
+++ b/contrib/curielogger/elk/6_x/es_config.sh
@@ -77,4 +77,6 @@ create_kibana_index_pattern () {
 wait_for_es
 define_es_index_template
 define_es_initial_index
-create_kibana_index_pattern
+if [ -z "$SKIP_KIBANA_INIT" ]; then
+	create_kibana_index_pattern
+fi


### PR DESCRIPTION
This new environment variable is to be set when kibana configuration is initialized by other means (manually, or by something outside this repository).

Signed-off-by: Xavier <xavier@reblaze.com>