### PR TITLE
[curielogger] do not initialize ES if not wanted

### DIFF
--- a/curiefense/curielogger/pkg/outputs/elasticsearch.go
+++ b/curiefense/curielogger/pkg/outputs/elasticsearch.go
@@ -148,6 +148,10 @@ func (es *ElasticSearch) ConfigureKibana() {
 
 func (es *ElasticSearch) ConfigureEs() {
 	log.Warn("The Elasticsearch output is deprecated and will be removed in the 1.5.0 release. More on the reasoning and discussion here: https://github.com/curiefense/curiefense/issues/317")
+
+	if !es.cfg.Initialize {
+		return
+	}
 	var res *esapi.Response
 	var err error
 	for i := 0; i < 60; i++ {


### PR DESCRIPTION
This makes curielogger skip the initial Elasticsearch configuration if `initialize` is set to False.
Signed-off-by: Xavier <xavier@reblaze.com>