### PR TITLE
[WIP][e2e] Fix e2e tests with minikube & filebeat

### DIFF
--- a/.github/workflows/e2e-minikube-filebeat.yml
+++ b/.github/workflows/e2e-minikube-filebeat.yml
@@ -65,9 +65,16 @@ jobs:
         if: ${{ failure() }}
         run: |
             kubectl -n curiefense describe pods
-            kubectl -n curiefense get logs -l app.kubernetes.io/name=curielogger
-            kubectl -n curiefense get logs -l app.kubernetes.io/name=curietasker
-            kubectl -n curiefense get logs -l app.kubernetes.io/name=uiserver
+            echo "--- Logs for curielogger ---"
+            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=curielogger
+            echo "--- Logs for curietasker ---"
+            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=curietasker
+            echo "--- Logs for uiserver ---"
+            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=uiserver
+            echo "--- Logs for kibana ---"
+            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=kibana
+            echo "--- Logs for elasticsearch ---"
+            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=elasticsearch
 
 
       - name: Publish Unit Test Results

--- a/deploy/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
@@ -77,7 +77,7 @@ spec:
         {{ end }}
 {{- if eq .Values.global.settings.curiefense_es_forwarder "filebeat" }}
         args:
-          - if [ ! -e /var/log/curielogger/curielogger.log ]; then mkfifo /var/log/curielogger/curielogger.log; fi; /bin/curielogger > >(tee /var/log/curielogger/curielogger.log)
+          - /bin/curielogger > /var/log/curielogger/curielogger.log
         command:
           - /bin/bash
           - -c

--- a/deploy/curiefense-helm/curiefense/values.yaml
+++ b/deploy/curiefense-helm/curiefense/values.yaml
@@ -23,7 +23,8 @@ global:
   settings:
     curiefense_metrics_prometheus_enabled: true
     curieconf_manifest_url: 's3://curiefense-test01/prod/manifest.json'
-    # supported types: 'fluentd', 'logstash'
+    # supported types: 'fluentd', 'logstash', 'filebeat'
+    # warning: the 'filebeat' mechanism relies on writing logs to a temporary file that is never deleted. Do not use in production.
     curiefense_es_forwarder: 'filebeat'
     # change curiefense_es_hosts if you supply your own elasticsearch server. Using several servers is not (yet?) fully supported by this chart
     curiefense_es_hosts: 'http://elasticsearch:9200/'


### PR DESCRIPTION
This PR fixes bugs in #341 which I merged too soon. Apologies @flaper87...

* Fix logs display in GitHub Actions
* Reverts to passing logs from curielogger to filebeat as a file, since filebeat [does not support FIFOs](https://github.com/elastic/beats/blob/23c546eeb3064c705a82da3ac103ac341318345b/filebeat/input/log/harvester.go#L526). That means logs are written to a temporary file that is never removed