### PR TITLE
Logrotate

### DIFF
--- a/deploy/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
+++ b/deploy/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
@@ -42,6 +42,20 @@ spec:
           - name: filebeat-configmap
             subPath: template.json
             mountPath: /usr/share/filebeat/template.json
+      - name: logrotate
+        image: blacklabelops/logrotate:1.2
+        env:
+        - name: LOGS_DIRECTORIES
+          value: "/var/log/curielogger"
+        - name: LOGROTATE_INTERVAL
+          value: hourly
+        - name: LOGROTATE_SIZE
+          value: "10M"
+        - name: LOGROTATE_COPIES
+          value: "10"
+        volumeMounts:
+          - name: curielogger
+            mountPath: /var/log/curielogger
 {{- end }}
       - name: curielogger
         env:

--- a/deploy/deploy-ci.sh
+++ b/deploy/deploy-ci.sh
@@ -6,7 +6,7 @@ eval "$(minikube docker-env)"
 
 GITTAG="$(git describe --tag --long --dirty)"
 DOCKER_DIR_HASH="$(git rev-parse --short=12 HEAD:curiefense)"
-export DOCKER_TAG="$GITTAG-$DOCKER_DIR_HASH"
+export DOCKER_TAG="${DOCKER_TAG:-$GITTAG-$DOCKER_DIR_HASH}"
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 WORKDIR=$(mktemp -d -t ci-XXXXXXXXXX)


### PR DESCRIPTION
Don't let the curielogger log file grow indefinitely. Instead, make sure it is rotated and eventually deleted.

Logrotate is configured with the following settings:

Max file size: 10MB
Number of files kept: 10
Rotation happens hourly

Signed-off-by: Flavio Percoco <flavio@reblaze.com>