### PR TITLE
[filebeat] use rotatelogs instead of logrotate

### DIFF
--- a/curiefense/images/curielogger/Dockerfile
+++ b/curiefense/images/curielogger/Dockerfile
@@ -5,7 +5,7 @@ COPY curielogger .
 RUN go build -o build/curielogger ./cmd/grpc
 
 FROM alpine
-RUN apk update && apk add ca-certificates curl bash && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates curl bash apache2-utils && rm -rf /var/cache/apk/*
 RUN mkdir -p /etc/curielogger/
 COPY contrib /contrib
 COPY --from=builder /app/build/curielogger /bin


### PR DESCRIPTION
Using logrotate without copytruncate results in no logs being written
after rotation.

rotatelogs writes logs to files named curielogger.log, then
curielogger.1, .2, ... in a round robin manner. It does not truncate
logs, or split them across two log files when the max size is reached.

Rejected alternatives:
* using multilog (https://cr.yp.to/daemontools/multilog.html), as it
  doesn't handle logs that are over 2k bytes well (ours are)
* using svlogd: works, but would require creating a configuration file
  *in* the log folder. An init script or entrypoint.sh would be needed
* feeding filebeat using something other than files: not possible if we
  want json parsing.
* FIFO are not supported by filebeat

Signed-off-by: Xavier <xavier@reblaze.com>