### PR TITLE
Make urlencode/decode more resistant to bad arguments

### DIFF
--- a/curiefense/iptools/src/lib.rs
+++ b/curiefense/iptools/src/lib.rs
@@ -405,12 +405,20 @@ fn urldecode(input: String) -> Vec<u8> {
     out
 }
 
-fn decodeurl(_: &Lua, url: String) -> LuaResult<Option<String>> {
-    Ok(Some(String::from_utf8_lossy(&urldecode(url)).into_owned()))
+pub fn decodeurl(lua: &Lua, args: LuaMultiValue) -> LuaResult<Option<String>> {
+    let res: LuaResult<String> = FromLuaMulti::from_lua_multi(args, lua);
+    Ok(Some(match res {
+        Ok(url_str) => String::from_utf8_lossy(&urldecode(url_str)).into_owned(),
+        _ => "".into(),
+    }))
 }
 
-fn encodeurl(_: &Lua, url: String) -> LuaResult<Option<String>> {
-    Ok(Some(encode(&url)))
+pub fn encodeurl(lua: &Lua, args: LuaMultiValue) -> LuaResult<Option<String>> {
+    let res: LuaResult<String> = FromLuaMulti::from_lua_multi(args, lua);
+    Ok(Some(match res {
+        Ok(url_str) => encode(&url_str),
+        _ => "".into(),
+    }))
 }
 
 /////////////////////////////////////////

--- a/curiefense/iptools/test.lua
+++ b/curiefense/iptools/test.lua
@@ -37,4 +37,7 @@ print("add dazd", s:add("dazd","adz"))
 
 print(ipt.decodeurl("/foo%20bar/?baz=%32das"))
 print(ipt.encodeurl(ipt.decodeurl("/foo%20bar/?baz=%32das")))
+print(ipt.decodeurl("/foo%20bar/?baz=%32das", "extra"))
+print(ipt.decodeurl(nil))
+print(ipt.decodeurl())
 


### PR DESCRIPTION
Also added a few test cases to the Lua test file.

This is a bit different from the "fix" I pushed in the rust branch, as I kept the needless `Option` (function always returns with a string).