### PR TITLE
Define a struct for the request attributes

### DIFF
--- a/contrib/curielogger/elk/6_x/index_template.json
+++ b/contrib/curielogger/elk/6_x/index_template.json
@@ -112,7 +112,24 @@
                             "type": "object"
                         },
                         "attributes": {
-                            "type": "object"
+                          "type": "object",
+                          "properties": {
+                            "ip": {
+                              "type": "ip"
+                            },
+                            "ipnum": {
+                              "type": "integer"
+                            },
+                            "query": {
+                              "type": "text"
+                            },
+                            "uri": {
+                              "type": "keyword"
+                            },
+                            "path": {
+                              "type": "keyword"
+                            }
+                          }
                         },
                         "bodybytes": {
                             "type": "integer"

--- a/contrib/curielogger/elk/7_x/es_index_template.json
+++ b/contrib/curielogger/elk/7_x/es_index_template.json
@@ -121,7 +121,24 @@
               "type": "flattened"
             },
             "attributes": {
-              "type": "flattened"
+              "type": "object",
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "ipnum": {
+                  "type": "integer"
+                },
+                "query": {
+                  "type": "text"
+                },
+                "uri": {
+                  "type": "keyword"
+                },
+                "path": {
+                  "type": "keyword"
+                }
+              }
             },
             "bodybytes": {
               "type": "integer"

--- a/curiefense/curielogger/pkg/entities/curie_proxy_log.go
+++ b/curiefense/curielogger/pkg/entities/curie_proxy_log.go
@@ -5,7 +5,7 @@ type CurieProxyLog struct {
 	Cookies     map[string]string      `json:"cookies"`
 	Geo         map[string]interface{} `json:"geo"`
 	Arguments   map[string]string      `json:"arguments"`
-	Attributes  map[string]interface{} `json:"attributes"`
+	Attributes  RequestAttributes      `json:"attributes"`
 	Blocked     bool                   `json:"blocked"`
 	BlockReason map[string]interface{} `json:"block_reason"`
 	Tags        []string               `json:"tags"`

--- a/curiefense/curielogger/pkg/entities/log_entry.go
+++ b/curiefense/curielogger/pkg/entities/log_entry.go
@@ -5,5 +5,4 @@ import ald "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
 type LogEntry struct {
 	FullEntry *ald.HTTPAccessLogEntry
 	CfLog     CuriefenseLog
-	//CurieProxyLog CurieProxyLog
 }

--- a/curiefense/curielogger/pkg/entities/misc.go
+++ b/curiefense/curielogger/pkg/entities/misc.go
@@ -58,6 +58,15 @@ type NameValue struct {
 	Value string `json:"value"`
 }
 
+type RequestAttributes struct {
+	ipnum  uint32 `json:"ipnum,omitempty"`
+	IP     string `json:"ip,omitempty"`
+	Query  string `json:"query,omitempty"`
+	URI    string `json:"uri,omitempty"`
+	Path   string `json:"path,omitempty"`
+	Method string `json:"method,omitempty"`
+}
+
 type Request struct {
 	RequestId    string                 `json:"requestid"`
 	Scheme       string                 `json:"scheme"`
@@ -67,7 +76,7 @@ type Request struct {
 	Cookies      map[string]string      `json:"cookies"`
 	Arguments    map[string]string      `json:"arguments"`
 	Geo          map[string]interface{} `json:"geo"`
-	Attributes   map[string]interface{} `json:"attributes"`
+	Attributes   RequestAttributes      `json:"attributes"`
 }
 
 type Response struct {

--- a/curiefense/curielogger/pkg/metrics.go
+++ b/curiefense/curielogger/pkg/metrics.go
@@ -2,15 +2,16 @@ package pkg
 
 import (
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
 	"github.com/curiefense/curiefense/curielogger/pkg/entities"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"net/http"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -124,13 +125,13 @@ func (m *Metrics) add(e *entities.LogEntry) {
 	tags := e.CfLog.Tags
 	blocked := strconv.FormatBool(e.CfLog.Blocked)
 	var method string
-	if m, ok := e.CfLog.Request.Attributes["method"]; ok {
-		method = fmt.Sprintf("%v", m)
+	if e.CfLog.Request.Attributes.Method != "" {
+		method = e.CfLog.Request.Attributes.Method
 	}
 
 	var uri string
-	if u, ok := e.CfLog.Request.Attributes["uri"]; ok {
-		uri = fmt.Sprintf("%v", u)
+	if e.CfLog.Request.Attributes.URI != "" {
+		uri = e.CfLog.Request.Attributes.URI
 	}
 
 	labels := makeLabels(e.CfLog.Response.Code, method, uri, e.CfLog.Upstream.RemoteAddress, blocked, tags)

--- a/deploy/filebeat/template.json
+++ b/deploy/filebeat/template.json
@@ -120,7 +120,24 @@
               "type": "flattened"
             },
             "attributes": {
-              "type": "flattened"
+              "type": "object",
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "ipnum": {
+                  "type": "integer"
+                },
+                "query": {
+                  "type": "text"
+                },
+                "uri": {
+                  "type": "keyword"
+                },
+                "path": {
+                  "type": "keyword"
+                }
+              }
             },
             "bodybytes": {
               "type": "integer"


### PR DESCRIPTION
The request attributes are quite consistent. Curielogger should define a mapping
for them instead of keeping them dynamic. This will help building dashboards, queries,
etc.

fixes curiefense#395


Signed-off-by: Flavio Percoco <flavio@reblaze.com>