### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/curiefense/images/confserver/Dockerfile
+++ b/curiefense/images/confserver/Dockerfile
@@ -16,6 +16,6 @@ RUN /usr/bin/apt-get update && \
 COPY bootstrap /bootstrap
 COPY init /init
 COPY curieconf-utils /curieconf-utils
-RUN cd /curieconf-utils ; pip3 install .
+RUN cd /curieconf-utils ; pip3 install --no-cache-dir .
 COPY curieconf-server /curieconf-server
-RUN cd /curieconf-server ; pip3 install .
+RUN cd /curieconf-server ; pip3 install --no-cache-dir .

--- a/curiefense/images/curiesync/Dockerfile
+++ b/curiefense/images/curiesync/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && \
 	rm -rf /var/lib/apt/lists/*
 
 COPY curieconf-utils /curieconf-utils
-RUN cd /curieconf-utils ; pip3 install .
+RUN cd /curieconf-utils ; pip3 install --no-cache-dir .
 COPY curieconf-client /curieconf-client
-RUN cd /curieconf-client ; pip3 install .
+RUN cd /curieconf-client ; pip3 install --no-cache-dir .
 COPY init /init
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/bin/bash", "/init/pull.sh"]

--- a/curiefense/images/curietasker/Dockerfile
+++ b/curiefense/images/curietasker/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update && \
 
 COPY curieconf-server/curieconf/confserver/json/tag-rules.schema /tag-rules.schema
 COPY curieconf-utils /curieconf-utils
-RUN cd /curieconf-utils ; pip3 install .
+RUN cd /curieconf-utils ; pip3 install --no-cache-dir .
 COPY curieconf-client /curieconf-client
-RUN cd /curieconf-client ; pip3 install .
+RUN cd /curieconf-client ; pip3 install --no-cache-dir .
 COPY curietasker /curietasker
-RUN cd /curietasker ; pip3 install .
+RUN cd /curietasker ; pip3 install --no-cache-dir .
 COPY init /init
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/bin/bash", "/init/run.sh"]


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>