### PR TITLE
Add an nginx-ingress container

### DIFF
--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -26,7 +26,7 @@ if [ -n "$TESTING" ]; then
     echo "Building only image $TESTIMG"
 else
     IMAGES=(confserver curielogger curieproxy-istio curieproxy-envoy \
-        curieproxy-nginx curiesync curietasker grafana prometheus \
+        curieproxy-nginx curiefense-nginx-ingress curiesync curietasker grafana prometheus \
         redis uiserver fluentd)
 fi
 

--- a/curiefense/images/curiefense-nginx-ingress/Dockerfile
+++ b/curiefense/images/curiefense-nginx-ingress/Dockerfile
@@ -1,0 +1,65 @@
+ARG RUSTBIN_TAG=latest
+FROM curiefense/curiefense-rustbuild-focal:${RUSTBIN_TAG} AS rustbin
+FROM docker.io/nginx/nginx-ingress:1.11.3 as nginx-ingress
+FROM docker.io/openresty/openresty:focal as openresty
+
+USER root
+RUN groupadd --system --gid 101 nginx \
+    && useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx 
+
+RUN apt-get update \
+    && apt-get install -y \
+        libcap2-bin \
+        libhyperscan5 \
+        rsyslog \
+	python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        python3-magic \
+	python3-xattr \
+        python3-netifaces \
+    && rm -rf /var/lib/apt/lists/*
+
+# bucket credentials will be provided by docker-compose or k8s secrets, if needed
+RUN ln -s /run/secrets/s3cfg/s3cfg /root/.s3cfg
+
+COPY curieconf-utils /curieconf-utils
+RUN cd /curieconf-utils ; pip3 install .
+
+COPY curieconf-client /curieconf-client
+RUN cd /curieconf-client ; pip3 install .
+
+COPY init /curiesync
+
+COPY --from=nginx-ingress /nginx* /
+
+RUN mkdir -p /var/lib/nginx /etc/nginx/secrets /etc/nginx/stream-conf.d /var/cache/nginx \
+        && mkdir -p /var/lib/openresty /var/run/openresty /var/cache/openresty \
+        && ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/sbin/nginx \
+        && ln -sf /usr/local/openresty/nginx/conf/* /etc/nginx/ \
+	&& chown -R nginx:0 /etc/nginx /etc/nginx/secrets /var/cache/nginx /var/lib/nginx /nginx* \
+        && chown -R nginx:0 /var/lib/openresty /var/run/openresty /var/cache/openresty /usr/local/openresty \
+	&& setcap 'cap_net_bind_service=+ep' /usr/local/openresty/nginx/sbin/nginx \
+	&& setcap -v 'cap_net_bind_service=+ep' /usr/local/openresty/nginx/sbin/nginx  \
+	&& rm -f /etc/nginx/conf.d/*
+
+RUN sed -i "/^http {/a log_format curiefenselog escape=none '$request_map';" /nginx.tmpl \
+        && sed -i "/^http {/a lua_package_path '/lua/?.lua;;';" /nginx.tmpl
+
+RUN openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=fr/O=curiefense/CN=testsystem" -keyout /etc/ssl/certificate.key -out /etc/ssl/certificate.crt
+
+COPY curieproxy/lua/shared-objects/*.so /usr/local/lib/lua/5.1/
+COPY --from=rustbin /root/curiefense.so /usr/local/lib/lua/5.1/
+
+COPY curieproxy/config /bootstrap-config/config
+COPY curieproxy/lua /lua
+RUN rm -f /lua/session.lua && ln -s /lua/session_rust_nginx.lua /lua/session.lua
+
+ENTRYPOINT ["/curiefense-nginx.sh"]
+
+RUN mkdir /config && chmod a+rwxt /config
+RUN mkfifo /nginx-accesslogs
+
+COPY curiefense-nginx.sh /curiefense-nginx.sh
+COPY rsyslog.conf /etc/rsyslog.conf
+

--- a/curiefense/images/curiefense-nginx-ingress/curieconf-client
+++ b/curiefense/images/curiefense-nginx-ingress/curieconf-client
@@ -1,0 +1,1 @@
+../../curieconf/client

--- a/curiefense/images/curiefense-nginx-ingress/curieconf-utils
+++ b/curiefense/images/curiefense-nginx-ingress/curieconf-utils
@@ -1,0 +1,1 @@
+../../curieconf/utils

--- a/curiefense/images/curiefense-nginx-ingress/curiefense-nginx.sh
+++ b/curiefense/images/curiefense-nginx-ingress/curiefense-nginx.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+rsyslogd -n -iNONE &
+
+/curiesync/pull.sh &
+
+/nginx-ingress "$@"

--- a/curiefense/images/curiefense-nginx-ingress/curieproxy
+++ b/curiefense/images/curiefense-nginx-ingress/curieproxy
@@ -1,0 +1,1 @@
+../../curieproxy

--- a/curiefense/images/curiefense-nginx-ingress/init
+++ b/curiefense/images/curiefense-nginx-ingress/init
@@ -1,0 +1,1 @@
+../curiesync/init

--- a/curiefense/images/curiefense-nginx-ingress/rsyslog.conf
+++ b/curiefense/images/curiefense-nginx-ingress/rsyslog.conf
@@ -1,0 +1,16 @@
+module(load="imuxsock") # provides support for local system logging
+module(load="imudp")
+input(type="imudp" port="514")
+
+$FileOwner syslog
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+$PrivDropToUser syslog
+$PrivDropToGroup syslog
+$WorkDirectory /var/spool/rsyslog
+
+*.* /var/log/syslog
+action(type="omfwd" Target="curielogger" Port="9514" Protocol="tcp")
+

--- a/curiefense/images/curiesync/init/pull.sh
+++ b/curiefense/images/curiesync/init/pull.sh
@@ -12,6 +12,10 @@ info () {
     fi
 }
 
+if [ -f /etc/curiefense/curiesync.env ]; then
+	# shellcheck disable=SC1091
+	source /etc/curiefense/curiesync.env
+fi
 
 if [ "$RUN_MODE" = "SYNC_ONCE" ]; then
     info "Synchronizing once"


### PR DESCRIPTION
This container is build from the curieproxy-nginx container, openresty container, and kubernetes-ingress container.
It allows to use the nginx-ingress controller with openresty, which is a build of nginx with support for external
lua code execution.