### PR TITLE
Fix tag rules logging

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/tagging.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/tagging.rs
@@ -91,7 +91,13 @@ pub fn tag_request(is_human: bool, cfg: &Config, rinfo: &RequestInfo) -> (Tags, 
                 if a.atype == SimpleActionT::Monitor || (a.atype == SimpleActionT::Challenge && is_human) {
                     continue;
                 }
-                return (tags, SimpleDecision::Action(a.clone(), Some(serde_json::json!("tag action"))));
+                return (
+                    tags,
+                    SimpleDecision::Action(
+                        a.clone(),
+                        Some(serde_json::json!({"initiator": "tag action", "tags": psection.tags})),
+                    ),
+                );
             }
         }
     }

--- a/curiefense/curieproxy/rust/luatests/config/json/profiling-lists.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/profiling-lists.json
@@ -414,5 +414,34 @@
       "tags": [
          "actionredirect"
       ]
+   },
+   {
+      "id": "49aea5a8d96b",
+      "name": "foo",
+      "source": "self-managed",
+      "mdate": "2021-07-01T09:50:58.505Z",
+      "notes": "Check action",
+      "active": true,
+      "action": {
+         "type": "default"
+      },
+      "tags": [
+         "tagbyip"
+      ],
+      "rule": {
+         "relation": "OR",
+         "sections": [
+            {
+               "relation": "OR",
+               "entries": [
+                  [
+                     "ip",
+                     "12.13.14.15",
+                     ""
+                  ]
+               ]
+            }
+         ]
+      }
    }
 ]

--- a/curiefense/curieproxy/rust/luatests/raw_requests/actions.json
+++ b/curiefense/curieproxy/rust/luatests/raw_requests/actions.json
@@ -1,0 +1,30 @@
+[
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/dqsqsdqsdcqsd",
+      "user-agent": "dummy",
+      "x-forwarded-for": "12.13.14.15"
+    },
+    "name": "test block by ip tagging",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 503,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:12-13-14-15",
+        "sante",
+        "urlmap-entry:default",
+        "wafid:default-waf",
+        "urlmap:default-entry",
+        "aclname:default-acl",
+        "aclid:--default--",
+        "asn:7018",
+        "tagbyip"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Tag rules generated an invalid log format, where the "reason" item was a
string.