### PR TITLE
Allow to running rsyslog as non-privileged user

### DIFF
--- a/curiefense/curielogger/cmd/grpc/syslog.go
+++ b/curiefense/curielogger/cmd/grpc/syslog.go
@@ -30,15 +30,16 @@ func syslogInit(srv *syslogServer, v *viper.Viper) {
 	server.SetHandler(handler)
 	log.Infof("syslog server listening on 9514")
 	server.ListenTCP("0.0.0.0:9514")
-	server.ListenUDP("0.0.0.0:9514")
 
 	go func(channel syslog.LogPartsChannel) {
 		for logParts := range srv.channel {
+			log.Debugf("PARTS %v", logParts)
 			var cfLog entities.CuriefenseLog
 			if !strings.HasPrefix(logParts["content"].(string), "nginx: ") {
 				continue
 			}
 			content := strings.TrimPrefix(logParts["content"].(string), "nginx: ")
+			log.Debugf("CONTENT %v", content)
 			err := json.Unmarshal([]byte(content), &cfLog)
 			if err != nil {
 				log.Errorf("Error occurred during unmarshalling. Error: %s", err.Error())

--- a/curiefense/images/curiefense-nginx-ingress/Dockerfile
+++ b/curiefense/images/curiefense-nginx-ingress/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /var/lib/nginx /etc/nginx/secrets /etc/nginx/stream-conf.d /var/cac
 	&& setcap -v 'cap_net_bind_service=+ep' /usr/sbin/rsyslogd  \
     && chown -R nginx:0 /var/lib/syslog /var/log/syslog
 
-RUN sed -i "/^http {/a log_format curiefenselog escape=none '$request_map';" /nginx.tmpl \
+RUN sed -i "/^http {/a log_format curiefenselog escape=none '\$request_map';" /nginx.tmpl \
         && sed -i "/^http {/a lua_package_path '/lua/?.lua;;';" /nginx.tmpl
 
 COPY curieproxy/lua/shared-objects/*.so /usr/local/lib/lua/5.1/

--- a/curiefense/images/curiefense-nginx-ingress/Dockerfile
+++ b/curiefense/images/curiefense-nginx-ingress/Dockerfile
@@ -44,6 +44,8 @@ RUN mkdir -p /var/lib/nginx /etc/nginx/secrets /etc/nginx/stream-conf.d /var/cac
 	&& rm -f /etc/nginx/conf.d/* \
     && mkdir -p /var/lib/syslog \
     && touch /var/log/syslog \
+	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/rsyslogd  \
+	&& setcap -v 'cap_net_bind_service=+ep' /usr/sbin/rsyslogd  \
     && chown -R nginx:0 /var/lib/syslog /var/log/syslog
 
 RUN sed -i "/^http {/a log_format curiefenselog escape=none '$request_map';" /nginx.tmpl \

--- a/curiefense/images/curiefense-nginx-ingress/Dockerfile
+++ b/curiefense/images/curiefense-nginx-ingress/Dockerfile
@@ -5,7 +5,7 @@ FROM docker.io/openresty/openresty:focal as openresty
 
 USER root
 RUN groupadd --system --gid 101 nginx \
-    && useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx 
+    && useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx
 
 RUN apt-get update \
     && apt-get install -y \
@@ -34,19 +34,20 @@ COPY init /curiesync
 COPY --from=nginx-ingress /nginx* /
 
 RUN mkdir -p /var/lib/nginx /etc/nginx/secrets /etc/nginx/stream-conf.d /var/cache/nginx \
-        && mkdir -p /var/lib/openresty /var/run/openresty /var/cache/openresty \
-        && ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/sbin/nginx \
-        && ln -sf /usr/local/openresty/nginx/conf/* /etc/nginx/ \
+    && mkdir -p /var/lib/openresty /var/run/openresty /var/cache/openresty \
+    && ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/sbin/nginx \
+    && ln -sf /usr/local/openresty/nginx/conf/* /etc/nginx/ \
 	&& chown -R nginx:0 /etc/nginx /etc/nginx/secrets /var/cache/nginx /var/lib/nginx /nginx* \
-        && chown -R nginx:0 /var/lib/openresty /var/run/openresty /var/cache/openresty /usr/local/openresty \
+    && chown -R nginx:0 /var/lib/openresty /var/run/openresty /var/cache/openresty /usr/local/openresty \
 	&& setcap 'cap_net_bind_service=+ep' /usr/local/openresty/nginx/sbin/nginx \
 	&& setcap -v 'cap_net_bind_service=+ep' /usr/local/openresty/nginx/sbin/nginx  \
-	&& rm -f /etc/nginx/conf.d/*
+	&& rm -f /etc/nginx/conf.d/* \
+    && mkdir -p /var/lib/syslog \
+    && touch /var/log/syslog \
+    && chown -R nginx:0 /var/lib/syslog /var/log/syslog
 
 RUN sed -i "/^http {/a log_format curiefenselog escape=none '$request_map';" /nginx.tmpl \
         && sed -i "/^http {/a lua_package_path '/lua/?.lua;;';" /nginx.tmpl
-
-RUN openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=fr/O=curiefense/CN=testsystem" -keyout /etc/ssl/certificate.key -out /etc/ssl/certificate.crt
 
 COPY curieproxy/lua/shared-objects/*.so /usr/local/lib/lua/5.1/
 COPY --from=rustbin /root/curiefense.so /usr/local/lib/lua/5.1/

--- a/curiefense/images/curiefense-nginx-ingress/rsyslog.conf
+++ b/curiefense/images/curiefense-nginx-ingress/rsyslog.conf
@@ -1,14 +1,9 @@
-module(load="imuxsock") # provides support for local system logging
-module(load="imudp")
-input(type="imudp" port="514")
+module(load="imuxsock" SysSock.Name="/var/lib/syslog/log")
 
-$FileOwner syslog
 $FileGroup adm
 $FileCreateMode 0640
 $DirCreateMode 0755
 $Umask 0022
-$PrivDropToUser syslog
-$PrivDropToGroup syslog
 $WorkDirectory /var/spool/rsyslog
 
 *.* /var/log/syslog

--- a/curiefense/images/curiefense-nginx-ingress/rsyslog.conf
+++ b/curiefense/images/curiefense-nginx-ingress/rsyslog.conf
@@ -1,4 +1,6 @@
 module(load="imuxsock" SysSock.Name="/var/lib/syslog/log")
+module(load="imudp")
+input(type="imudp" port="514")
 
 $FileGroup adm
 $FileCreateMode 0640
@@ -7,5 +9,5 @@ $Umask 0022
 $WorkDirectory /var/spool/rsyslog
 
 *.* /var/log/syslog
-action(type="omfwd" Target="curielogger" Port="9514" Protocol="tcp")
+action(type="omfwd" Target="curielogger" Port="9514" Protocol="tcp" KeepAlive="on")
 


### PR DESCRIPTION
Remove bind to 514, and uses /var/lib/syslog/log as the socket
path instead of /dev/log

Signed-off-by: Flavio Percoco <flavio@reblaze.com>