### PR TITLE
Tag rules - we do not require at lease one tag

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/json/tag-rules.schema
+++ b/curiefense/curieconf/server/curieconf/confserver/json/tag-rules.schema
@@ -42,7 +42,8 @@
       "items": {
         "type": "string"
       },
-      "uniqueItems": true
+      "uniqueItems": true,
+      "minItems": 1
     },
     "action": {
         "type": "object",


### PR DESCRIPTION
Added a requirement of at least one tag for Tag Rule tags list in Tag Rules json schema
Closes https://github.com/curiefense/curiefense/issues/430

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>