### PR TITLE
compose: set envoy log level with an environment variable

### DIFF
--- a/curiefense/images/curieproxy-envoy/init/start_curiefense.sh
+++ b/curiefense/images/curieproxy-envoy/init/start_curiefense.sh
@@ -13,6 +13,7 @@ fi
 TADDR="${TARGET_ADDRESS:-echo}"
 TPORT="${TARGET_PORT:-8080}"
 XFF="${XFF_TRUSTED_HOPS:-1}"
+ENVOY_LOG_LEVEL="{ENVOY_LOG_LEVEL:-error}"
 
 sed -e "s/XFF_TRUSTED/$XFF/" /etc/envoy/envoy.yaml.head > /etc/envoy/envoy.yaml
 if [ -f /run/secrets/curieproxysslcrt ]; then
@@ -23,8 +24,7 @@ sed -e "s/TARGET_ADDRESS/$TADDR/" -e "s/TARGET_PORT/$TPORT/" /etc/envoy/envoy.ya
 while true
 do
 	# shellcheck disable=SC2086
-	/usr/local/bin/envoy -c /etc/envoy/envoy.yaml --service-cluster proxy --log-level debug $ENVOY_ARGS --concurrency 1 #NO concurrency PICKS THE NUM OF CORES
-    # /usr/local/bin/envoy -c /etc/envoy/envoy.yaml --service-cluster proxy --log-level error $ENVOY_ARGS #--concurrency 1 NO concurrency PICKS THE NUM OF CORES
+    /usr/local/bin/envoy -c /etc/envoy/envoy.yaml --service-cluster proxy --log-level "$ENVOY_LOG_LEVEL" $ENVOY_ARGS #--concurrency 1 NO concurrency PICKS THE NUM OF CORES
 	sleep 1
 done
 

--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,6 +1,7 @@
 ENVOY_UID=0
 DOCKER_TAG=main
 XFF_TRUSTED_HOPS=1
+ENVOY_LOG_LEVEL=error
 
 CURIE_BUCKET_LINK=file:///bucket/prod/manifest.json
 #CURIE_BUCKET_LINK=s3://bucket/prod/manifest.json

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
       - TARGET_ADDRESS=echo
       - TARGET_PORT=8080
       - XFF_TRUSTED_HOPS
+      - ENVOY_LOG_LEVEL
     networks:
       curiemesh:
         aliases:


### PR DESCRIPTION
Set the default log level to "error" instead of "debug" which generates
>10GB worth of logs per days on an idle instance.