### PR TITLE
Fix flow checks tags

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/flow.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/flow.rs
@@ -1,3 +1,4 @@
+use crate::Logs;
 use std::collections::HashMap;
 
 use crate::config::flow::{FlowElement, SequenceKey};
@@ -35,19 +36,29 @@ fn flow_match(reqinfo: &RequestInfo, tags: &Tags, elem: &FlowElement) -> bool {
     elem.select.iter().all(|e| check_selector_cond(reqinfo, tags, e))
 }
 
+enum FlowResult {
+    NonLast,
+    LastOk,
+    LastBlock,
+}
+
 fn check_flow(
     cnx: &mut redis::Connection,
     redis_key: &str,
     step: u32,
     ttl: u64,
     is_last: bool,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<FlowResult> {
     // first, read from REDIS how many steps already passed
     let mlistlen: Option<usize> = redis::cmd("LLEN").arg(redis_key).query(cnx)?;
     let listlen = mlistlen.unwrap_or(0);
 
     if is_last {
-        Ok(step as usize == listlen)
+        if step as usize == listlen {
+            Ok(FlowResult::LastOk)
+        } else {
+            Ok(FlowResult::LastBlock)
+        }
     } else {
         if step as usize == listlen {
             let (_, mexpire): ((), Option<i64>) = redis::pipe()
@@ -63,14 +74,15 @@ fn check_flow(
             }
         }
         // never block if not the last step!
-        Ok(true)
+        Ok(FlowResult::NonLast)
     }
 }
 
 pub fn flow_check(
+    logs: &mut Logs,
     flows: &HashMap<SequenceKey, Vec<FlowElement>>,
     reqinfo: &RequestInfo,
-    tags: &Tags,
+    tags: &mut Tags,
 ) -> anyhow::Result<SimpleDecision> {
     let sequence_key = session_sequence_key(reqinfo);
     match flows.get(&sequence_key) {
@@ -79,12 +91,29 @@ pub fn flow_check(
             let mut bad = SimpleDecision::Pass;
             // do not establish the connection if unneeded
             let mut cnx = crate::redis::redis_conn()?;
-            for elem in elems.iter().filter(|e| flow_match(reqinfo, tags, e)) {
+            for elem in elems.iter() {
+                logs.debug(format!("Testing flow control {} (step {})", elem.name, elem.step));
+                if !flow_match(reqinfo, &tags, elem) {
+                    continue;
+                }
+                logs.debug(format!("Checking flow control {} (step {})", elem.name, elem.step));
                 let redis_key = build_redis_key(reqinfo, &elem.key, &elem.id, &elem.name);
-                if check_flow(&mut cnx, &redis_key, elem.step, elem.ttl, elem.is_last)? {
-                    return Ok(SimpleDecision::Pass);
-                } else {
-                    bad = SimpleDecision::Action(elem.action.clone(), Some(serde_json::json!({"initiator":"flow_check"})));
+                match check_flow(&mut cnx, &redis_key, elem.step, elem.ttl, elem.is_last)? {
+                    FlowResult::LastOk => {
+                        tags.insert(&elem.name);
+                        return Ok(SimpleDecision::Pass);
+                    }
+                    FlowResult::LastBlock => {
+                        tags.insert(&elem.name);
+                        bad = SimpleDecision::Action(
+                            elem.action.clone(),
+                            Some(serde_json::json!({
+                                "initiator": "flow_check",
+                                "name": elem.name
+                            })),
+                        );
+                    }
+                    FlowResult::NonLast => {}
                 }
             }
             Ok(bad)

--- a/curiefense/curieproxy/rust/curiefense/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/lib.rs
@@ -128,7 +128,7 @@ pub fn inspect_generic_request_map<GH: Grasshopper>(
         }
     }
 
-    match flow_check(&flows, &reqinfo, &tags) {
+    match flow_check(logs, &flows, &reqinfo, &mut tags) {
         Err(rr) => logs.error(rr),
         Ok(SimpleDecision::Pass) => {}
         // TODO, check for monitor

--- a/curiefense/curieproxy/rust/curiefense/src/session.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/session.rs
@@ -269,10 +269,11 @@ pub fn session_waf_check(session_id: &str) -> anyhow::Result<Decision> {
 
 pub fn session_flow_check(session_id: &str) -> anyhow::Result<Decision> {
     let uuid: Uuid = session_id.parse()?;
+    let mut logs = Logs::default();
 
     let sdecision = with_config(|cfg| {
         with_request_info(uuid, |rinfo| {
-            with_tags(uuid, |tags| flow_check(&cfg.flows, rinfo, tags))
+            with_tags_mut(uuid, |tags| flow_check(&mut logs, &cfg.flows, rinfo, tags))
         })
     });
     Ok(sdecision?.into_decision_no_challenge())


### PR DESCRIPTION
On the last step of a flow check test, the request should be tagged with
the flow rule name.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>