### PR TITLE
Make sure there always is a block reason

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/flow.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/flow.rs
@@ -99,10 +99,10 @@ pub fn flow_check(
                         tags.insert(&elem.name);
                         bad = SimpleDecision::Action(
                             elem.action.clone(),
-                            Some(serde_json::json!({
+                            serde_json::json!({
                                 "initiator": "flow_check",
                                 "name": elem.name
-                            })),
+                            }),
                         );
                     }
                     FlowResult::NonLast => {}

--- a/curiefense/curieproxy/rust/curiefense/src/interface.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 #[derive(Debug, Clone)]
 pub enum SimpleDecision {
     Pass,
-    Action(SimpleAction, Option<serde_json::Value>),
+    Action(SimpleAction, serde_json::Value),
 }
 
 #[derive(Debug, Clone)]
@@ -264,6 +264,7 @@ impl SimpleAction {
             }
             SimpleActionT::Redirect(to) => {
                 let mut headers = HashMap::new();
+                action.content = "You are being redirected".into();
                 headers.insert("Location".into(), to.clone());
                 action.atype = ActionType::Block;
                 action.headers = Some(headers);
@@ -279,7 +280,7 @@ impl SimpleAction {
         is_human: bool,
         mgh: &Option<GH>,
         headers: &RequestField,
-        reason: Option<serde_json::Value>,
+        reason: serde_json::Value,
     ) -> Decision {
         let mut action = match self.to_action(is_human) {
             None => match (mgh, headers.get("user-agent")) {
@@ -288,20 +289,16 @@ impl SimpleAction {
             },
             Some(a) => a,
         };
-        if let Some(r) = reason {
-            action.reason = r;
-        }
+        action.reason = reason;
         Decision::Action(action)
     }
 
-    pub fn to_decision_no_challenge(&self, reason: Option<serde_json::Value>) -> Decision {
+    pub fn to_decision_no_challenge(&self, reason: serde_json::Value) -> Decision {
         let mut action = match self.to_action(true) {
             None => Action::default(),
             Some(a) => a,
         };
-        if let Some(r) = reason {
-            action.reason = r;
-        }
+        action.reason = reason;
         Decision::Action(action)
     }
 }

--- a/curiefense/curieproxy/rust/curiefense/src/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/limit.rs
@@ -40,7 +40,11 @@ fn limit_react(logs: &mut Logs, cnx: &mut redis::Connection, limit: &Limit, key:
             println!("*** Redis error {}", rr);
         }
     }
-    SimpleDecision::Action(limit.action.clone(), None)
+    SimpleDecision::Action(limit.action.clone(), serde_json::json!({
+        "initiator": "limit",
+        "limitname": limit.name,
+        "key": key
+    }))
 }
 
 fn redis_check_limit(

--- a/curiefense/curieproxy/rust/curiefense/src/tagging.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/tagging.rs
@@ -95,7 +95,7 @@ pub fn tag_request(is_human: bool, cfg: &Config, rinfo: &RequestInfo) -> (Tags, 
                     tags,
                     SimpleDecision::Action(
                         a.clone(),
-                        Some(serde_json::json!({"initiator": "tag action", "tags": psection.tags})),
+                        serde_json::json!({"initiator": "tag action", "tags": psection.tags}),
                     ),
                 );
             }


### PR DESCRIPTION
Changed the definition of SimpleAction so that the reason is no longer
optional.

Added decision reasons for flows and limits.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>