### PR TITLE
EXPIRE ban keys for rate limiting

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/config/raw.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/raw.rs
@@ -192,6 +192,7 @@ pub struct RawActionParams {
     pub reason: Option<String>,
     pub content: Option<String>,
     pub location: Option<String>,
+    pub ttl: Option<String>,
 }
 
 impl std::default::Default for RawActionParams {
@@ -204,6 +205,7 @@ impl std::default::Default for RawActionParams {
             reason: None,
             content: None,
             location: None,
+            ttl: None,
         }
     }
 }

--- a/curiefense/curieproxy/rust/luatests/config/json/flow-control.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/flow-control.json
@@ -1,7 +1,9 @@
 [
     {
         "exclude": [],
-        "include": ["all"],
+        "include": [
+            "all"
+        ],
         "name": "Flow Control same uri",
         "key": [
             {
@@ -16,7 +18,9 @@
                 "headers": {
                     "host": "www.example.com"
                 },
-                "args": {"step": "^1$"}
+                "args": {
+                    "step": "^1$"
+                }
             },
             {
                 "method": "GET",
@@ -25,7 +29,9 @@
                 "headers": {
                     "host": "www.example.com"
                 },
-                "args": {"step": "^2$"}
+                "args": {
+                    "step": "^2$"
+                }
             },
             {
                 "method": "GET",
@@ -34,7 +40,9 @@
                 "headers": {
                     "host": "www.example.com"
                 },
-                "args": {"step": "^3$"}
+                "args": {
+                    "step": "^3$"
+                }
             }
         ],
         "active": true,
@@ -46,8 +54,12 @@
         "id": "c03dabe4b9ca"
     },
     {
-        "exclude": ["deny"],
-        "include": ["all"],
+        "exclude": [
+            "deny"
+        ],
+        "include": [
+            "all"
+        ],
         "name": "Flow Control (simple)",
         "key": [
             {
@@ -87,6 +99,51 @@
         "notes": "abc",
         "action": {
             "type": "default"
+        },
+        "ttl": 4,
+        "id": "d03dabe4b9ca"
+    },
+    {
+        "exclude": [],
+        "include": [
+            "all"
+        ],
+        "name": "Flow Control (ban)",
+        "key": [
+            {
+                "attrs": "ip"
+            }
+        ],
+        "sequence": [
+            {
+                "method": "GET",
+                "uri": "/rlban1",
+                "cookies": {},
+                "headers": {
+                    "host": "www.example.com"
+                },
+                "args": {}
+            },
+            {
+                "method": "GET",
+                "uri": "/rlban2",
+                "cookies": {},
+                "headers": {
+                    "host": "www.example.com"
+                },
+                "args": {}
+            }
+        ],
+        "active": true,
+        "notes": "abc",
+        "action": {
+            "type": "ban",
+            "params": {
+                "ttl": "3600",
+                "action": {
+                    "type": "default"
+                }
+            }
         },
         "ttl": 4,
         "id": "d03dabe4b9ca"

--- a/curiefense/curieproxy/rust/luatests/config/json/limits.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/limits.json
@@ -227,5 +227,41 @@
         "pairwith": {
             "self": "self"
         }
+    },
+    {
+        "id": "f971e92459e2",
+        "name": "Rate limit ban",
+        "description": "3 requests per 2 seconds",
+        "ttl": "2",
+        "limit": "3",
+        "action": {
+            "type": "ban",
+            "params": {
+                "ttl": "4",
+                "action": {
+                    "type": "default"
+                }
+            }
+        },
+        "include": {
+            "headers": {},
+            "cookies": {},
+            "args": {},
+            "attrs": {}
+        },
+        "exclude": {
+            "headers": {},
+            "cookies": {},
+            "args": {},
+            "attrs": {}
+        },
+        "key": [
+            {
+                "attrs": "ip"
+            }
+        ],
+        "pairwith": {
+            "self": "self"
+        }
     }
 ]

--- a/curiefense/curieproxy/rust/luatests/config/json/urlmap.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/urlmap.json
@@ -114,6 +114,17 @@
                 ]
             },
             {
+                "name": "ban-test",
+                "match": "/limits/ban-test",
+                "acl_profile": "__default__",
+                "acl_active": true,
+                "waf_profile": "__default__",
+                "waf_active": true,
+                "limit_ids": [
+                    "f971e92459e2"
+                ]
+            },
+            {
                 "match": "/",
                 "name": "default",
                 "acl_profile": "__default__",

--- a/curiefense/curieproxy/rust/luatests/ratelimit/test-ban.json
+++ b/curiefense/curieproxy/rust/luatests/ratelimit/test-ban.json
@@ -1,0 +1,62 @@
+[
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/limits/ban-test",
+      ":authority": "localhost:30081"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/limits/ban-test",
+      ":authority": "localhost:30081"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/limits/ban-test",
+      ":authority": "localhost:30081"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/limits/ban-test",
+      ":authority": "localhost:30081"
+    },
+    "delay": 3,
+    "pass": false
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/limits/ban-test",
+      ":authority": "localhost:30081"
+    },
+    "delay": 5,
+    "pass": false
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/limits/ban-test",
+      ":authority": "localhost:30081"
+    },
+    "delay": 0,
+    "pass": true
+  }
+]


### PR DESCRIPTION
Banned users would be banned forever. This patch EXPIRE the ban key, and
adds tests to make sure this work properly. This should fix #435.

However, the problem is still open for flow control.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>