### PR TITLE
Include/exclude clauses for rate limiting now uses tags

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/config/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/limit.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use crate::config::raw::{RawLimit, RawLimitSelector};
 use crate::config::utils::{
@@ -16,8 +17,8 @@ pub struct Limit {
     pub limit: u64,
     pub ttl: u64,
     pub action: SimpleAction,
-    pub exclude: Vec<RequestSelectorCondition>,
-    pub include: Vec<RequestSelectorCondition>,
+    pub exclude: HashSet<String>,
+    pub include: HashSet<String>,
     pub pairwith: Option<RequestSelector>,
     pub key: Vec<RequestSelector>,
 }
@@ -55,8 +56,8 @@ impl Limit {
                 limit: rawlimit.limit.parse().with_context(|| "when converting the limit")?,
                 ttl: rawlimit.ttl.parse().with_context(|| "when converting the ttl")?,
                 action: SimpleAction::resolve(&rawlimit.action).with_context(|| "when resolving the action entry")?,
-                exclude: resolve_selectors(rawlimit.exclude).with_context(|| "when resolving the exclude entry")?,
-                include: resolve_selectors(rawlimit.include).with_context(|| "when resolving the include entry")?,
+                include: rawlimit.include.into_iter().collect(),
+                exclude: rawlimit.exclude.into_iter().collect(),
                 pairwith,
                 key,
             },
@@ -100,8 +101,8 @@ mod tests {
                 ttl: 0,
                 id: String::new(),
                 action: SimpleAction::from_reason(format!("limit {}", name)),
-                include: Vec::new(),
-                exclude: Vec::new(),
+                include: HashSet::new(),
+                exclude: HashSet::new(),
                 key: Vec::new(),
                 pairwith: None,
             }

--- a/curiefense/curieproxy/rust/curiefense/src/config/raw.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/raw.rs
@@ -121,9 +121,9 @@ pub struct RawLimit {
     #[serde(default)]
     pub key: Vec<HashMap<String, String>>,
     #[serde(default)]
-    pub include: RawLimitSelector,
+    pub include: Vec<String>,
     #[serde(default)]
-    pub exclude: RawLimitSelector,
+    pub exclude: Vec<String>,
     pub pairwith: HashMap<String, String>,
     pub action: RawAction,
 }

--- a/curiefense/curieproxy/rust/curiefense/src/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/limit.rs
@@ -72,6 +72,16 @@ fn redis_check_limit(
     Ok(current > limit as i64)
 }
 
+fn limit_match(tags: &Tags, elem: &Limit) -> bool {
+    if elem.exclude.iter().any(|e| tags.contains(e)) {
+        return false;
+    }
+    if !(elem.include.is_empty() || elem.include.iter().any(|e| tags.contains(e))) {
+        return false;
+    }
+    true
+}
+
 pub fn limit_check(
     logs: &mut Logs,
     url_map_name: &str,
@@ -95,20 +105,8 @@ pub fn limit_check(
     };
 
     for limit in limits {
-        if limit
-            .exclude
-            .iter()
-            .any(|selcond| check_selector_cond(reqinfo, tags, selcond))
-        {
+        if !limit_match(tags, limit) {
             logs.debug(format!("limit {} excluded", limit.name));
-            continue;
-        }
-        if !limit
-            .include
-            .iter()
-            .all(|selcond| check_selector_cond(reqinfo, tags, selcond))
-        {
-            logs.debug(format!("limit {} not included", limit.name));
             continue;
         }
 

--- a/curiefense/curieproxy/rust/luatests/config/json/limits.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/limits.json
@@ -8,18 +8,8 @@
         "action": {
             "type": "default"
         },
-        "include": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
-        "exclude": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
+        "include": [],
+        "exclude": [],
         "key": [
             {
                 "attrs": "country"
@@ -38,18 +28,8 @@
         "action": {
             "type": "default"
         },
-        "include": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
-        "exclude": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
+        "include": [],
+        "exclude": [],
         "key": [
             {
                 "attrs": "ip"
@@ -68,20 +48,10 @@
         "action": {
             "type": "default"
         },
-        "include": {
-            "headers": {
-                "foo": "bar"
-            },
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
-        "exclude": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
+        "include": [
+            "hdrfoobar"
+        ],
+        "exclude": [],
         "key": [
             {
                 "attrs": "ip"
@@ -100,20 +70,10 @@
         "action": {
             "type": "default"
         },
-        "include": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
-        "exclude": {
-            "headers": {
-                "foo": "bar"
-            },
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
+        "include": [],
+        "exclude": [
+            "hdrfoobar"
+        ],
         "key": [
             {
                 "attrs": "ip"
@@ -133,21 +93,11 @@
             "type": "response",
             "content": "body"
         },
-        "include": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {
-                "company": "CLOUDFARE",
-                "authority": "foo"
-            }
-        },
-        "exclude": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
+        "include": [
+            "asn:CLOUDFARE",
+            "authority:foo"
+        ],
+        "exclude": [],
         "key": [
             {
                 "attrs": "ip"
@@ -169,18 +119,8 @@
                 "location": "/1234"
             }
         },
-        "include": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
-        "exclude": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
+        "include": [],
+        "exclude": [],
         "key": [
             {
                 "attrs": "ip"
@@ -205,20 +145,10 @@
                 }
             }
         },
-        "include": {
-            "cookies": {},
-            "headers": {},
-            "args": {},
-            "attrs": {
-                "country": "us"
-            }
-        },
-        "exclude": {
-            "cookies": {},
-            "headers": {},
-            "args": {},
-            "attrs": {}
-        },
+        "include": [
+            "geo:united-states"
+        ],
+        "exclude": [],
         "key": [
             {
                 "attrs": "ip"
@@ -243,18 +173,8 @@
                 }
             }
         },
-        "include": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
-        "exclude": {
-            "headers": {},
-            "cookies": {},
-            "args": {},
-            "attrs": {}
-        },
+        "include": [],
+        "exclude": [],
         "key": [
             {
                 "attrs": "ip"

--- a/curiefense/curieproxy/rust/luatests/config/json/profiling-lists.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/profiling-lists.json
@@ -5,6 +5,39 @@
       },
       "active": true,
       "entries_relation": "OR",
+      "id": "hdrfoobar",
+      "mdate": "2020-05-23T00:04:41",
+      "name": "header foo=bar",
+      "notes": "note",
+      "rule": {
+         "relation": "AND",
+         "sections": [
+            {
+               "entries": [
+                  [
+                     "headers",
+                     [
+                        "foo",
+                        "bar"
+                     ],
+                     "..."
+                  ]
+               ],
+               "relation": "OR"
+            }
+         ]
+      },
+      "source": "self-managed",
+      "tags": [
+         "hdrfoobar"
+      ]
+   },
+   {
+      "action": {
+         "type": "monitor"
+      },
+      "active": true,
+      "entries_relation": "OR",
       "id": "arg_deny",
       "mdate": "2020-05-23T00:04:41",
       "name": "args deny",


### PR DESCRIPTION
This commit modifies tests so that they conform to the new format.

However, it does not modify anything in the configuration server or the
UI!

Signed-off-by: Simon Marechal <bartavelle@gmail.com>