### PR TITLE
Make sure the test container is temporary

### DIFF
--- a/curiefense/curieproxy/rust/Makefile
+++ b/curiefense/curieproxy/rust/Makefile
@@ -48,5 +48,6 @@ test-nodeps:
 						 -v `pwd`/luatests/run.sh:/home/builder/run.sh \
 						 -v `pwd`/luatests/config/json:/config/current/config/json \
 						 -v `pwd`/luatests:/home/builder/luatests \
+						 --rm \
 						 -w /home/builder -t curiefense/rustbuild:latest \
 						 /bin/sh /home/builder/run.sh


### PR DESCRIPTION
A persistent container was created for each test. This makes it
temporary.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>