### PR TITLE
Wafonly inspect

### DIFF
--- a/curiefense/curieproxy/rust/NOTES.md
+++ b/curiefense/curieproxy/rust/NOTES.md
@@ -2,8 +2,7 @@
 
 An initial implementation of all filtering components had been written. The following is currently handled in Lua:
 
- * getting the information required by the filtering engine:
-    - 
+ * getting the information required by the filtering engine
  * request replies
  * logging
 
@@ -38,6 +37,46 @@ It will perform all the curieproxy checks, and return a pair, with:
 
  * a JSON-encoded Decision (see below),
  * a list of strings, containing all encountered errors
+
+### `inspect_waf`
+
+Takes five arguments:
+
+ * *meta*, a Lua table containing the following entries:
+
+    - `path`: the "path" part of the HTTP request, containing the full, raw URI (ie. something like `/a/b?c=d&e=f`);
+    - `method`: the HTTP verb (such as `GET`, `POST`, etc.);
+    - `authority`: optionnaly, the `:authority` HTTP2 header, if available.
+    
+ * *headers*, a Lua table containing the HTTP headers (keys are the header names, values the header values).
+ * *body*, optionnaly, the HTTP request body. Note that large bodies will have a performance impact, and should be size-limited before calling this function.
+ * *ip*, the string-encoded IP address in canonical format.
+ * *waf_id*, the id of the waf profile to apply
+
+It will perform all the curieproxy checks, and return a pair, with:
+
+ * a JSON-encoded Decision (see below),
+ * a list of strings, containing all encountered errors
+
+In order to test drive it:
+ * configuration files are at the expected place, but only the `waf-profiles.json` and `waf-signatures.json` files are required ;
+ * modify the session lua file this way:
+
+```diff
+--- a/curiefense/curieproxy/lua/session_nginx.lua
++++ b/curiefense/curieproxy/lua/session_nginx.lua
+@@ -36,8 +36,9 @@ function session_rust_nginx.inspect(handle)
+     --   * method : the HTTP verb
+     --   * authority : optionally, the HTTP2 authority field
+     local response
+-    response, err = curiefense.inspect_request(
+-        meta, headers, body_content, ip_str, grasshopper
++    response, err = curiefense.inspect_waf(
++        meta, headers, body_content, ip_str, "__default__"
+     )
+ 
+     if err then
+```
 
 # Session API
 

--- a/curiefense/curieproxy/rust/curiefense-lua/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense-lua/src/lib.rs
@@ -16,6 +16,83 @@ use curiefense::interface::{Decision, Grasshopper};
 use curiefense::logs::Logs;
 use curiefense::session;
 use curiefense::utils::{map_request, InspectionResult};
+use curiefense::waf_check_generic_request_map;
+
+// ******************************************
+// WAF ONLY CHECKS
+// ******************************************
+
+/// Lua interface to the inspection function
+///
+/// args are
+/// * meta (contains keys "method", "path", and optionally "authority")
+/// * headers
+/// * (opt) body
+/// * ip addr
+/// * (opt) grasshopper
+#[allow(clippy::type_complexity)]
+#[allow(clippy::unnecessary_wraps)]
+fn lua_inspect_waf(
+    _lua: &Lua,
+    args: (
+        HashMap<String, String>, // meta
+        HashMap<String, String>, // headers
+        Option<LuaString>,       // maybe body
+        String,                  // ip
+        String,                  // waf_id
+    ),
+) -> LuaResult<(String, Option<String>)> {
+    let (meta, headers, lua_body, str_ip, waf_id) = args;
+
+    let res = match lua_body {
+        None => inspect_waf("/config/current/config", meta, headers, None, str_ip, waf_id),
+        Some(body) => inspect_waf(
+            "/config/current/config",
+            meta,
+            headers,
+            Some(body.as_bytes()),
+            str_ip,
+            waf_id,
+        ),
+    };
+
+    Ok(match res {
+        Err(rr) => (
+            Decision::Pass.to_json_raw(serde_json::Value::Null, Logs::default()),
+            Some(rr),
+        ),
+        Ok(ir) => ir.into_json(),
+    })
+}
+
+/// Rust-native inspection top level function
+fn inspect_waf(
+    configpath: &str,
+    meta: HashMap<String, String>,
+    headers: HashMap<String, String>,
+    mbody: Option<&[u8]>,
+    ip: String,
+    waf_id: String,
+) -> Result<InspectionResult, String> {
+    let mut logs = Logs::default();
+    logs.debug("Inspection init");
+    let rmeta: RequestMeta = RequestMeta::from_map(meta)?;
+
+    let reqinfo = map_request(&mut logs, ip, headers, rmeta, mbody)?;
+
+    let dec = waf_check_generic_request_map(configpath, &reqinfo, &waf_id, &mut logs);
+    Ok(InspectionResult {
+        decision: dec,
+        tags: None,
+        logs,
+        err: None,
+        rinfo: Some(reqinfo),
+    })
+}
+
+// ******************************************
+// FULL CHECKS
+// ******************************************
 
 /// Lua interface to the inspection function
 ///
@@ -199,6 +276,8 @@ fn curiefense(lua: &Lua) -> LuaResult<LuaTable> {
 
     // end-to-end inspection
     exports.set("inspect_request", lua.create_function(lua_inspect_request)?)?;
+    // waf inspection
+    exports.set("inspect_waf", lua.create_function(lua_inspect_waf)?)?;
 
     // session functions
     exports.set(

--- a/curiefense/curieproxy/rust/curiefense/src/config.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config.rs
@@ -71,6 +71,7 @@ pub struct Config {
     pub last_mod: SystemTime,
     pub container_name: Option<String>,
     pub flows: HashMap<SequenceKey, Vec<FlowElement>>,
+    pub waf_profiles: HashMap<String, WafProfile>,
 }
 
 fn from_map<V: Clone>(mp: &HashMap<String, V>, k: &str) -> Result<V, String> {
@@ -159,12 +160,12 @@ impl Config {
         let mut urlmaps: Vec<Matching<HostMap>> = Vec::new();
 
         let limits = Limit::resolve(logs, rawlimits);
-        let wafprofiles = WafProfile::resolve(logs, rawwafprofiles);
+        let waf_profiles = WafProfile::resolve(logs, rawwafprofiles);
         let acls = rawacls.into_iter().map(|a| (a.id.clone(), a)).collect();
 
         // build the entries while looking for the default entry
         for rawmap in rawmaps {
-            let (entries, default_entry) = Config::resolve_url_maps(logs, rawmap.map, &limits, &acls, &wafprofiles);
+            let (entries, default_entry) = Config::resolve_url_maps(logs, rawmap.map, &limits, &acls, &waf_profiles);
             if default_entry.is_none() {
                 logs.warning(format!(
                     "HostMap entry '{}', id '{}' does not have a default entry",
@@ -208,6 +209,7 @@ impl Config {
             last_mod,
             container_name,
             flows,
+            waf_profiles,
         }
     }
 
@@ -293,6 +295,7 @@ impl Config {
             default: None,
             container_name: None,
             flows: HashMap::new(),
+            waf_profiles: HashMap::new(),
         }
     }
 }

--- a/curiefense/curieproxy/rust/curiefense/src/waf.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/waf.rs
@@ -123,10 +123,6 @@ impl Default for Omitted {
 }
 
 /// Runs the WAF part of curiefense
-///
-/// TODO:
-/// * resolve hyperscan matches into policies
-/// * handle excluded waf policies
 pub fn waf_check(
     rinfo: &RequestInfo,
     profile: &WafProfile,

--- a/curiefense/curieproxy/rust/luatests/raw_requests/direct-tags.json
+++ b/curiefense/curieproxy/rust/luatests/raw_requests/direct-tags.json
@@ -59,11 +59,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&allow=allow",
+      ":path": "/direct?allow=allow&allowbot=allowbot",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + allow",
+    "name": "allow + allowbot",
     "response": {
       "action": "pass",
       "tags": [
@@ -79,8 +79,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "allowbot",
-        "allow"
+        "allow",
+        "allowbot"
       ]
     }
   },
@@ -88,11 +88,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&allow=YWxsb3c%3D",
+      ":path": "/direct?allow=YWxsb3c%3D&allowbot=YWxsb3dib3Q%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + allow (b64)",
+    "name": "allow + allowbot (b64)",
     "response": {
       "action": "pass",
       "tags": [
@@ -108,8 +108,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "allowbot",
-        "allow"
+        "allow",
+        "allowbot"
       ]
     }
   },
@@ -117,11 +117,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?deny=deny&allow=allow",
+      ":path": "/direct?allow=allow&deny=deny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "deny + allow",
+    "name": "allow + deny",
     "response": {
       "action": "pass",
       "tags": [
@@ -137,8 +137,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "deny",
-        "allow"
+        "allow",
+        "deny"
       ]
     }
   },
@@ -146,11 +146,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&allow=YWxsb3c%3D",
+      ":path": "/direct?allow=YWxsb3c%3D&deny=ZGVueQ%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "deny + allow (b64)",
+    "name": "allow + deny (b64)",
     "response": {
       "action": "pass",
       "tags": [
@@ -166,8 +166,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "deny",
-        "allow"
+        "allow",
+        "deny"
       ]
     }
   },
@@ -239,11 +239,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?forcedeny=forcedeny&allow=allow",
+      ":path": "/direct?allow=allow&forcedeny=forcedeny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "forcedeny + allow",
+    "name": "allow + forcedeny",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -261,8 +261,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "forcedeny",
-        "allow"
+        "allow",
+        "forcedeny"
       ]
     }
   },
@@ -270,11 +270,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allow=YWxsb3c%3D",
+      ":path": "/direct?allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "forcedeny + allow (b64)",
+    "name": "allow + forcedeny (b64)",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -292,8 +292,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "forcedeny",
-        "allow"
+        "allow",
+        "forcedeny"
       ]
     }
   },
@@ -359,11 +359,697 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&deny=deny&allow=allow",
+      ":path": "/direct?allow=allow&allowbot=allowbot&deny=deny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + deny + allow",
+    "name": "allow + allowbot + deny",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "allowbot",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&allowbot=YWxsb3dib3Q%3D&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + allowbot + deny (b64)",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "allowbot",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=allow&denybot=denybot&allowbot=allowbot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + denybot + allowbot",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "denybot",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&denybot=ZGVueWJvdA%3D%3D&allowbot=YWxsb3dib3Q%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + denybot + allowbot (b64)",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "denybot",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=allow&forcedeny=forcedeny&allowbot=allowbot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + forcedeny + allowbot",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "forcedeny",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55&allowbot=YWxsb3dib3Q%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + forcedeny + allowbot (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "forcedeny",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=allow&bypass=bypass&allowbot=allowbot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + bypass + allowbot",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "bypass",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&bypass=YnlwYXNz&allowbot=YWxsb3dib3Q%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + bypass + allowbot (b64)",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "bypass",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=allow&denybot=denybot&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + denybot + deny",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 247,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "denybot",
+        "deny",
+        "challenge-phase01"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&denybot=ZGVueWJvdA%3D%3D&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + denybot + deny (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 247,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "denybot",
+        "deny",
+        "challenge-phase01"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=allow&forcedeny=forcedeny&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + forcedeny + deny",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "forcedeny",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + forcedeny + deny (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "forcedeny",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=allow&bypass=bypass&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + bypass + deny",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "bypass",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&bypass=YnlwYXNz&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + bypass + deny (b64)",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "bypass",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=allow&forcedeny=forcedeny&denybot=denybot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + forcedeny + denybot",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "forcedeny",
+        "denybot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55&denybot=ZGVueWJvdA%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + forcedeny + denybot (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "forcedeny",
+        "denybot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=allow&bypass=bypass&denybot=denybot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + bypass + denybot",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "bypass",
+        "denybot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allow=YWxsb3c%3D&bypass=YnlwYXNz&denybot=ZGVueWJvdA%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allow + bypass + denybot (b64)",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allow",
+        "bypass",
+        "denybot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?bypass=bypass&allow=allow&forcedeny=forcedeny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "bypass + allow + forcedeny",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "bypass",
+        "allow",
+        "forcedeny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?bypass=YnlwYXNz&allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "bypass + allow + forcedeny (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "bypass",
+        "allow",
+        "forcedeny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&allow=allow&bypass=bypass",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allow + bypass",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "allow",
+        "bypass"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allow=YWxsb3c%3D&bypass=YnlwYXNz",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allow + bypass (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "allow",
+        "bypass"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allowbot=allowbot&allow=allow",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allowbot + allow",
     "response": {
       "action": "pass",
       "tags": [
@@ -380,7 +1066,6 @@
         "bot",
         "sante",
         "allowbot",
-        "deny",
         "allow"
       ]
     }
@@ -389,11 +1074,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&deny=ZGVueQ%3D%3D&allow=YWxsb3c%3D",
+      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&allow=YWxsb3c%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + deny + allow (b64)",
+    "name": "allowbot + allow (b64)",
     "response": {
       "action": "pass",
       "tags": [
@@ -410,7 +1095,6 @@
         "bot",
         "sante",
         "allowbot",
-        "deny",
         "allow"
       ]
     }
@@ -419,11 +1103,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&allow=allow&denybot=denybot",
+      ":path": "/direct?allowbot=allowbot&allow=allow&deny=deny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + allow + denybot",
+    "name": "allowbot + allow + deny",
     "response": {
       "action": "pass",
       "tags": [
@@ -441,7 +1125,7 @@
         "sante",
         "allowbot",
         "allow",
-        "denybot"
+        "deny"
       ]
     }
   },
@@ -449,11 +1133,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&allow=YWxsb3c%3D&denybot=ZGVueWJvdA%3D%3D",
+      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&allow=YWxsb3c%3D&deny=ZGVueQ%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + allow + denybot (b64)",
+    "name": "allowbot + allow + deny (b64)",
     "response": {
       "action": "pass",
       "tags": [
@@ -471,7 +1155,67 @@
         "sante",
         "allowbot",
         "allow",
-        "denybot"
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allowbot=allowbot&denybot=denybot&allow=allow",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allowbot + denybot + allow",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allowbot",
+        "denybot",
+        "allow"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&denybot=ZGVueWJvdA%3D%3D&allow=YWxsb3c%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "allowbot + denybot + allow (b64)",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "allowbot",
+        "denybot",
+        "allow"
       ]
     }
   },
@@ -543,11 +1287,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&allow=allow&bypass=bypass",
+      ":path": "/direct?allowbot=allowbot&bypass=bypass&allow=allow",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + allow + bypass",
+    "name": "allowbot + bypass + allow",
     "response": {
       "action": "pass",
       "tags": [
@@ -564,8 +1308,8 @@
         "bot",
         "sante",
         "allowbot",
-        "allow",
-        "bypass"
+        "bypass",
+        "allow"
       ]
     }
   },
@@ -573,11 +1317,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&allow=YWxsb3c%3D&bypass=YnlwYXNz",
+      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&bypass=YnlwYXNz&allow=YWxsb3c%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + allow + bypass (b64)",
+    "name": "allowbot + bypass + allow (b64)",
     "response": {
       "action": "pass",
       "tags": [
@@ -594,386 +1338,8 @@
         "bot",
         "sante",
         "allowbot",
-        "allow",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=deny&allow=allow&denybot=denybot",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + allow + denybot",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 247,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "allow",
-        "denybot",
-        "challenge-phase01"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&allow=YWxsb3c%3D&denybot=ZGVueWJvdA%3D%3D",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + allow + denybot (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 247,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "allow",
-        "denybot",
-        "challenge-phase01"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=deny&forcedeny=forcedeny&allow=allow",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + forcedeny + allow",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "forcedeny",
+        "bypass",
         "allow"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&forcedeny=Zm9yY2VkZW55&allow=YWxsb3c%3D",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + forcedeny + allow (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "forcedeny",
-        "allow"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=deny&allow=allow&bypass=bypass",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + allow + bypass",
-    "response": {
-      "action": "pass",
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "allow",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&allow=YWxsb3c%3D&bypass=YnlwYXNz",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + allow + bypass (b64)",
-    "response": {
-      "action": "pass",
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "allow",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?forcedeny=forcedeny&allow=allow&denybot=denybot",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "forcedeny + allow + denybot",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "forcedeny",
-        "allow",
-        "denybot"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allow=YWxsb3c%3D&denybot=ZGVueWJvdA%3D%3D",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "forcedeny + allow + denybot (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "forcedeny",
-        "allow",
-        "denybot"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?allow=allow&denybot=denybot&bypass=bypass",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "allow + denybot + bypass",
-    "response": {
-      "action": "pass",
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "allow",
-        "denybot",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?allow=YWxsb3c%3D&denybot=ZGVueWJvdA%3D%3D&bypass=YnlwYXNz",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "allow + denybot + bypass (b64)",
-    "response": {
-      "action": "pass",
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "allow",
-        "denybot",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?forcedeny=forcedeny&allow=allow&bypass=bypass",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "forcedeny + allow + bypass",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "forcedeny",
-        "allow",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allow=YWxsb3c%3D&bypass=YnlwYXNz",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "forcedeny + allow + bypass (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "forcedeny",
-        "allow",
-        "bypass"
       ]
     }
   },
@@ -1277,11 +1643,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&deny=deny&denybot=denybot",
+      ":path": "/direct?allowbot=allowbot&denybot=denybot&deny=deny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + deny + denybot",
+    "name": "allowbot + denybot + deny",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1300,8 +1666,8 @@
         "bot",
         "sante",
         "allowbot",
-        "deny",
-        "denybot"
+        "denybot",
+        "deny"
       ]
     }
   },
@@ -1309,11 +1675,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&deny=ZGVueQ%3D%3D&denybot=ZGVueWJvdA%3D%3D",
+      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&denybot=ZGVueWJvdA%3D%3D&deny=ZGVueQ%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + deny + denybot (b64)",
+    "name": "allowbot + denybot + deny (b64)",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1332,8 +1698,8 @@
         "bot",
         "sante",
         "allowbot",
-        "deny",
-        "denybot"
+        "denybot",
+        "deny"
       ]
     }
   },
@@ -1341,11 +1707,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&deny=deny&forcedeny=forcedeny",
+      ":path": "/direct?allowbot=allowbot&forcedeny=forcedeny&deny=deny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + deny + forcedeny",
+    "name": "allowbot + forcedeny + deny",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1364,8 +1730,8 @@
         "bot",
         "sante",
         "allowbot",
-        "deny",
-        "forcedeny"
+        "forcedeny",
+        "deny"
       ]
     }
   },
@@ -1373,11 +1739,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&deny=ZGVueQ%3D%3D&forcedeny=Zm9yY2VkZW55",
+      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&forcedeny=Zm9yY2VkZW55&deny=ZGVueQ%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + deny + forcedeny (b64)",
+    "name": "allowbot + forcedeny + deny (b64)",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1396,8 +1762,8 @@
         "bot",
         "sante",
         "allowbot",
-        "deny",
-        "forcedeny"
+        "forcedeny",
+        "deny"
       ]
     }
   },
@@ -1405,11 +1771,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&deny=deny&bypass=bypass",
+      ":path": "/direct?allowbot=allowbot&bypass=bypass&deny=deny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + deny + bypass",
+    "name": "allowbot + bypass + deny",
     "response": {
       "action": "pass",
       "tags": [
@@ -1426,8 +1792,8 @@
         "bot",
         "sante",
         "allowbot",
-        "deny",
-        "bypass"
+        "bypass",
+        "deny"
       ]
     }
   },
@@ -1435,11 +1801,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&deny=ZGVueQ%3D%3D&bypass=YnlwYXNz",
+      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&bypass=YnlwYXNz&deny=ZGVueQ%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + deny + bypass (b64)",
+    "name": "allowbot + bypass + deny (b64)",
     "response": {
       "action": "pass",
       "tags": [
@@ -1456,8 +1822,8 @@
         "bot",
         "sante",
         "allowbot",
-        "deny",
-        "bypass"
+        "bypass",
+        "deny"
       ]
     }
   },
@@ -1529,11 +1895,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&denybot=denybot&bypass=bypass",
+      ":path": "/direct?allowbot=allowbot&bypass=bypass&denybot=denybot",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + denybot + bypass",
+    "name": "allowbot + bypass + denybot",
     "response": {
       "action": "pass",
       "tags": [
@@ -1550,8 +1916,8 @@
         "bot",
         "sante",
         "allowbot",
-        "denybot",
-        "bypass"
+        "bypass",
+        "denybot"
       ]
     }
   },
@@ -1559,11 +1925,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&denybot=ZGVueWJvdA%3D%3D&bypass=YnlwYXNz",
+      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&bypass=YnlwYXNz&denybot=ZGVueWJvdA%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + denybot + bypass (b64)",
+    "name": "allowbot + bypass + denybot (b64)",
     "response": {
       "action": "pass",
       "tags": [
@@ -1580,8 +1946,8 @@
         "bot",
         "sante",
         "allowbot",
-        "denybot",
-        "bypass"
+        "bypass",
+        "denybot"
       ]
     }
   },
@@ -1589,11 +1955,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&allow=allow&forcedeny=forcedeny",
+      ":path": "/direct?bypass=bypass&allowbot=allowbot&forcedeny=forcedeny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + allow + forcedeny",
+    "name": "bypass + allowbot + forcedeny",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1611,8 +1977,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
+        "bypass",
         "allowbot",
-        "allow",
         "forcedeny"
       ]
     }
@@ -1621,11 +1987,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55",
+      ":path": "/direct?bypass=YnlwYXNz&allowbot=YWxsb3dib3Q%3D&forcedeny=Zm9yY2VkZW55",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + allow + forcedeny (b64)",
+    "name": "bypass + allowbot + forcedeny (b64)",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1643,8 +2009,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
+        "bypass",
         "allowbot",
-        "allow",
         "forcedeny"
       ]
     }
@@ -1653,11 +2019,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=allowbot&forcedeny=forcedeny&bypass=bypass",
+      ":path": "/direct?forcedeny=forcedeny&allowbot=allowbot&bypass=bypass",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + forcedeny + bypass",
+    "name": "forcedeny + allowbot + bypass",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1675,8 +2041,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "allowbot",
         "forcedeny",
+        "allowbot",
         "bypass"
       ]
     }
@@ -1685,11 +2051,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allowbot=YWxsb3dib3Q%3D&forcedeny=Zm9yY2VkZW55&bypass=YnlwYXNz",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allowbot=YWxsb3dib3Q%3D&bypass=YnlwYXNz",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allowbot + forcedeny + bypass (b64)",
+    "name": "forcedeny + allowbot + bypass (b64)",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1707,8 +2073,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "allowbot",
         "forcedeny",
+        "allowbot",
         "bypass"
       ]
     }
@@ -1777,11 +2143,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?deny=deny&denybot=denybot",
+      ":path": "/direct?denybot=denybot&deny=deny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "deny + denybot",
+    "name": "denybot + deny",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -1799,253 +2165,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "deny",
-        "denybot"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&denybot=ZGVueWJvdA%3D%3D",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + denybot (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "denybot"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=deny&forcedeny=forcedeny",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + forcedeny",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "forcedeny"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&forcedeny=Zm9yY2VkZW55",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + forcedeny (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "forcedeny"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=deny&bypass=bypass",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + bypass",
-    "response": {
-      "action": "pass",
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&bypass=YnlwYXNz",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + bypass (b64)",
-    "response": {
-      "action": "pass",
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=deny&forcedeny=forcedeny&denybot=denybot",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + forcedeny + denybot",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "forcedeny",
-        "denybot"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&forcedeny=Zm9yY2VkZW55&denybot=ZGVueWJvdA%3D%3D",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + forcedeny + denybot (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "forcedeny",
-        "denybot"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=deny&denybot=denybot&bypass=bypass",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + denybot + bypass",
-    "response": {
-      "action": "pass",
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
         "denybot",
-        "bypass"
+        "deny"
       ]
     }
   },
@@ -2053,11 +2174,104 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&denybot=ZGVueWJvdA%3D%3D&bypass=YnlwYXNz",
+      ":path": "/direct?denybot=ZGVueWJvdA%3D%3D&deny=ZGVueQ%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "deny + denybot + bypass (b64)",
+    "name": "denybot + deny (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "denybot",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + deny",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + deny (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?bypass=bypass&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "bypass + deny",
     "response": {
       "action": "pass",
       "tags": [
@@ -2073,9 +2287,69 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "deny",
+        "bypass",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?bypass=YnlwYXNz&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "bypass + deny (b64)",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "bypass",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&denybot=denybot&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + denybot + deny",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
         "denybot",
-        "bypass"
+        "deny"
       ]
     }
   },
@@ -2083,11 +2357,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?deny=deny&allow=allow&forcedeny=forcedeny",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&denybot=ZGVueWJvdA%3D%3D&deny=ZGVueQ%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "deny + allow + forcedeny",
+    "name": "forcedeny + denybot + deny (b64)",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -2105,73 +2379,9 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "deny",
-        "allow",
-        "forcedeny"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + allow + forcedeny (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
-        "allow",
-        "forcedeny"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?deny=deny&forcedeny=forcedeny&bypass=bypass",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "deny + forcedeny + bypass",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "deny",
         "forcedeny",
-        "bypass"
+        "denybot",
+        "deny"
       ]
     }
   },
@@ -2179,11 +2389,71 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?deny=ZGVueQ%3D%3D&forcedeny=Zm9yY2VkZW55&bypass=YnlwYXNz",
+      ":path": "/direct?bypass=bypass&denybot=denybot&deny=deny",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "deny + forcedeny + bypass (b64)",
+    "name": "bypass + denybot + deny",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "bypass",
+        "denybot",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?bypass=YnlwYXNz&denybot=ZGVueWJvdA%3D%3D&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "bypass + denybot + deny (b64)",
+    "response": {
+      "action": "pass",
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "bypass",
+        "denybot",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&allow=allow&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allow + deny",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -2201,9 +2471,169 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "deny",
         "forcedeny",
-        "bypass"
+        "allow",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allow=YWxsb3c%3D&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allow + deny (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "allow",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&allowbot=allowbot&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allowbot + deny",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "allowbot",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allowbot=YWxsb3dib3Q%3D&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allowbot + deny (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "allowbot",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&bypass=bypass&deny=deny",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + bypass + deny",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "bypass",
+        "deny"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&bypass=YnlwYXNz&deny=ZGVueQ%3D%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + bypass + deny (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "bypass",
+        "deny"
       ]
     }
   },
@@ -2335,11 +2765,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?denybot=denybot&bypass=bypass",
+      ":path": "/direct?bypass=bypass&denybot=denybot",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "denybot + bypass",
+    "name": "bypass + denybot",
     "response": {
       "action": "pass",
       "tags": [
@@ -2355,8 +2785,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "denybot",
-        "bypass"
+        "bypass",
+        "denybot"
       ]
     }
   },
@@ -2364,11 +2794,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?denybot=ZGVueWJvdA%3D%3D&bypass=YnlwYXNz",
+      ":path": "/direct?bypass=YnlwYXNz&denybot=ZGVueWJvdA%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "denybot + bypass (b64)",
+    "name": "bypass + denybot (b64)",
     "response": {
       "action": "pass",
       "tags": [
@@ -2384,39 +2814,7 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "denybot",
-        "bypass"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?allow=allow&forcedeny=forcedeny&denybot=denybot",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "allow + forcedeny + denybot",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "allow",
-        "forcedeny",
+        "bypass",
         "denybot"
       ]
     }
@@ -2425,11 +2823,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55&denybot=ZGVueWJvdA%3D%3D",
+      ":path": "/direct?forcedeny=forcedeny&denybot=denybot&allow=allow",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allow + forcedeny + denybot (b64)",
+    "name": "forcedeny + denybot + allow",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -2447,8 +2845,136 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "allow",
         "forcedeny",
+        "denybot",
+        "allow"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&denybot=ZGVueWJvdA%3D%3D&allow=YWxsb3c%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + denybot + allow (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "denybot",
+        "allow"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&denybot=denybot&allowbot=allowbot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + denybot + allowbot",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "denybot",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&denybot=ZGVueWJvdA%3D%3D&allowbot=YWxsb3dib3Q%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + denybot + allowbot (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "denybot",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&bypass=bypass&denybot=denybot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + bypass + denybot",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "bypass",
         "denybot"
       ]
     }
@@ -2457,11 +2983,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?forcedeny=forcedeny&denybot=denybot&bypass=bypass",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&bypass=YnlwYXNz&denybot=ZGVueWJvdA%3D%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "forcedeny + denybot + bypass",
+    "name": "forcedeny + bypass + denybot (b64)",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -2480,8 +3006,8 @@
         "bot",
         "sante",
         "forcedeny",
-        "denybot",
-        "bypass"
+        "bypass",
+        "denybot"
       ]
     }
   },
@@ -2489,11 +3015,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?forcedeny=Zm9yY2VkZW55&denybot=ZGVueWJvdA%3D%3D&bypass=YnlwYXNz",
+      ":path": "/direct?forcedeny=forcedeny&allow=allow",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "forcedeny + denybot + bypass (b64)",
+    "name": "forcedeny + allow",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -2512,8 +3038,7 @@
         "bot",
         "sante",
         "forcedeny",
-        "denybot",
-        "bypass"
+        "allow"
       ]
     }
   },
@@ -2521,11 +3046,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allow=allow&forcedeny=forcedeny",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allow=YWxsb3c%3D",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allow + forcedeny",
+    "name": "forcedeny + allow (b64)",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -2543,71 +3068,8 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "allow",
-        "forcedeny"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "allow + forcedeny (b64)",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "allow",
-        "forcedeny"
-      ]
-    }
-  },
-  {
-    "headers": {
-      ":authority": "localhost:30081",
-      ":method": "GET",
-      ":path": "/direct?allow=allow&forcedeny=forcedeny&bypass=bypass",
-      "user-agent": "dummy",
-      "x-forwarded-for": "23.129.64.253"
-    },
-    "name": "allow + forcedeny + bypass",
-    "response": {
-      "action": "custom_response",
-      "block_mode": true,
-      "status": 403,
-      "tags": [
-        "all",
-        "geo:united-states",
-        "ip:23-129-64-253",
-        "aclname:from-tags",
-        "aclid:fromtags",
-        "wafname:default-waf",
-        "wafid:--default--",
-        "urlmap:default-entry",
-        "asn:396507",
-        "urlmap-entry:direct-association",
-        "bot",
-        "sante",
-        "allow",
         "forcedeny",
-        "bypass"
+        "allow"
       ]
     }
   },
@@ -2615,11 +3077,11 @@
     "headers": {
       ":authority": "localhost:30081",
       ":method": "GET",
-      ":path": "/direct?allow=YWxsb3c%3D&forcedeny=Zm9yY2VkZW55&bypass=YnlwYXNz",
+      ":path": "/direct?forcedeny=forcedeny&allowbot=allowbot&allow=allow",
       "user-agent": "dummy",
       "x-forwarded-for": "23.129.64.253"
     },
-    "name": "allow + forcedeny + bypass (b64)",
+    "name": "forcedeny + allowbot + allow",
     "response": {
       "action": "custom_response",
       "block_mode": true,
@@ -2637,9 +3099,231 @@
         "urlmap-entry:direct-association",
         "bot",
         "sante",
-        "allow",
         "forcedeny",
-        "bypass"
+        "allowbot",
+        "allow"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allowbot=YWxsb3dib3Q%3D&allow=YWxsb3c%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allowbot + allow (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "allowbot",
+        "allow"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&bypass=bypass&allow=allow",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + bypass + allow",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "bypass",
+        "allow"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&bypass=YnlwYXNz&allow=YWxsb3c%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + bypass + allow (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "bypass",
+        "allow"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&allowbot=allowbot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allowbot",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&allowbot=YWxsb3dib3Q%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + allowbot (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=forcedeny&bypass=bypass&allowbot=allowbot",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + bypass + allowbot",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "bypass",
+        "allowbot"
+      ]
+    }
+  },
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/direct?forcedeny=Zm9yY2VkZW55&bypass=YnlwYXNz&allowbot=YWxsb3dib3Q%3D",
+      "user-agent": "dummy",
+      "x-forwarded-for": "23.129.64.253"
+    },
+    "name": "forcedeny + bypass + allowbot (b64)",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403,
+      "tags": [
+        "all",
+        "geo:united-states",
+        "ip:23-129-64-253",
+        "aclname:from-tags",
+        "aclid:fromtags",
+        "wafname:default-waf",
+        "wafid:--default--",
+        "urlmap:default-entry",
+        "asn:396507",
+        "urlmap-entry:direct-association",
+        "bot",
+        "sante",
+        "forcedeny",
+        "bypass",
+        "allowbot"
       ]
     }
   },

--- a/curiefense/curieproxy/rust/luatests/waf_only/test-waf.json
+++ b/curiefense/curieproxy/rust/luatests/waf_only/test-waf.json
@@ -1,0 +1,475 @@
+[
+  {
+    "waf_id": "__default__",
+    "response": {
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "libinjection xss",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.129.64.253",
+      ":path": "\/test\/?a=1&b=%3Cscript%3Edocument.body.innerHTML=",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "__default__",
+    "response": {
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "sqli (header)",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.129.64.253",
+      ":path": "\/test\/",
+      ":method": "GET",
+      ":authority": "localhost:30081",
+      "malicious": "xp_cmdshell"
+    }
+  },
+  {
+    "waf_id": "__default__",
+    "response": {
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "sqli (args)",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.129.64.253",
+      ":path": "\/test\/?a=1&b=xp_cmdshell",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "__default__",
+    "response": {
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "sqli (cookies)",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.129.64.253",
+      "cookies": "xp_cmdshell",
+      ":path": "\/test\/",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "omitted",
+    "response": {
+      "action": "pass"
+    },
+    "name": "omit sqli",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.5.64.253",
+      ":path": "\/waf\/omitted?foo=xp_cmdshell",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "omitted",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "non omitted sqli (headers)",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.5.64.253",
+      ":path": "\/waf\/omitted",
+      ":method": "GET",
+      ":authority": "localhost:30081",
+      "malicious": "xp_cmdshell"
+    }
+  },
+  {
+    "waf_id": "__default__",
+    "response": {
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "other sqli",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "13.129.64.253",
+      ":path": "\/waf\/misc\/?v=information_schema%28",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "omitted",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "other sqli, not omitted",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "13.129.64.253",
+      ":path": "\/waf\/omitted\/?v=information_schema%28",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "__default__",
+    "response": {
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "two sqli",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "13.129.64.253",
+      ":path": "\/waf\/misc\/?v=information_schema%28&x=xp_cmdshell",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "omitted",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "two sqli, one omitted",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "13.129.64.253",
+      ":path": "\/waf\/omitted\/?v=information_schema%28&x=xp_cmdshell",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "noinject",
+    "response": {
+      "action": "pass"
+    },
+    "name": "no libinjection",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.129.64.253",
+      ":path": "\/waf\/noinjection\/foo",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "omitted",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "alphanum blocked",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "13.129.64.253",
+      ":path": "\/waf\/omitted\/?v=AZDGSDQZE16Z",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "noinject",
+    "response": {
+      "action": "pass"
+    },
+    "name": "alphanum skipped",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "13.129.64.253",
+      ":path": "\/waf\/noinjection\/?v=AZDGSDQZE16Z",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "too many args",
+    "headers": {
+      ":path": "\/waf\/args\/?a=A&b=B&c=C&d=D&e=E",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "passing",
+    "headers": {
+      ":path": "\/waf\/args\/?a=A&b=B&c=C",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args a",
+    "headers": {
+      ":path": "\/waf\/args\/?a=A",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args b",
+    "headers": {
+      ":path": "\/waf\/args\/?b=B",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args c",
+    "headers": {
+      ":path": "\/waf\/args\/?c=C",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args d",
+    "headers": {
+      ":path": "\/waf\/args\/?d=D",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args a (n)",
+    "headers": {
+      ":path": "\/waf\/args\/?a=1",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "test args b (n)",
+    "headers": {
+      ":path": "\/waf\/args\/?b=2",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "test args c (n)",
+    "headers": {
+      ":path": "\/waf\/args\/?c=3",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args d (n)",
+    "headers": {
+      ":path": "\/waf\/args\/?d=4",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args a (nosig)",
+    "headers": {
+      ":path": "\/waf\/args\/?a=AZDGSDQZE16Z",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args b (nosig)",
+    "headers": {
+      ":path": "\/waf\/args\/?b=AZDGSDQZE16Z",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args c (nosig)",
+    "headers": {
+      ":path": "\/waf\/args\/?c=AZDGSDQZE16Z",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "argschecks",
+    "response": {
+      "action": "pass"
+    },
+    "name": "test args d (nosig)",
+    "headers": {
+      ":path": "\/waf\/args\/?d=AZDGSDQZE16Z",
+      ":method": "GET",
+      "x-forwarded-for": "13.129.64.253",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "__default__",
+    "response": {
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "overlong header",
+    "headers": {
+      "x-forwarded-for": "13.129.64.253",
+      "long-header": "Overlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_headerOverlong_header",
+      ":path": "\/waf\/",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "e2e000000002",
+    "response": {
+      "action": "pass"
+    },
+    "name": "short headers ok",
+    "headers": {
+      "x-forwarded-for": "13.129.64.253",
+      ":path": "\/waf-short-headers\/",
+      ":method": "GET",
+      "short-header": "01234567890123456789012345678901234567890123456789",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "e2e000000002",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "short headers reject",
+    "headers": {
+      "x-forwarded-for": "13.129.64.253",
+      ":path": "\/waf-short-headers\/",
+      ":method": "GET",
+      "short-header": "01234567890123456789012345678901234567890123456789A",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "rr",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "restrict 1",
+    "headers": {
+      "x-forwarded-for": "13.129.64.253",
+      "regex-restrict": "invalid",
+      ":path": "\/rr\/blocklisted-value-regex-restrict-restrict",
+      ":method": "GET",
+      "short-header": "01234567890123456789012345678901234567890123456789A",
+      ":authority": "localhost:30081"
+    }
+  },
+  {
+    "waf_id": "rr",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "restrict 2",
+    "headers": {
+      "x-forwarded-for": "13.129.64.253",
+      "regex-norestrict": "invalid",
+      ":path": "\/rr\/blocklisted-value-regex-restrict-restrict",
+      ":method": "GET",
+      "short-header": "01234567890123456789012345678901234567890123456789A",
+      ":authority": "localhost:30081"
+    }
+  }
+]


### PR DESCRIPTION
This is the "WAF only" API feature, a function that only exposes the WAF filter, for integration with other tools.