### PR TITLE
Only tag limits that are hit

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/limit.rs
@@ -116,9 +116,6 @@ pub fn limit_check(
             continue;
         }
 
-        // every matching ratelimit rule is tagged by name
-        tags.insert(&limit.name);
-
         let key = match build_key(url_map_name, reqinfo, limit) {
             None => return SimpleDecision::Pass,
             Some(k) => k,
@@ -139,7 +136,10 @@ pub fn limit_check(
 
         match redis_check_limit(&mut redis, &key, limit.limit, limit.ttl, pairvalue) {
             Err(rr) => logs.error(rr),
-            Ok(true) => return limit_react(logs, &mut redis, limit, key),
+            Ok(true) => {
+                tags.insert(&limit.name);
+                return limit_react(logs, &mut redis, limit, key);
+            }
             Ok(false) => (),
         }
     }


### PR DESCRIPTION
This patch only tags with the limit name requests that hit the limit,
and not all requests where the limit has been checked.  If not done
this way, the tag-only action makes no sense.

Should fix #429.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>