### PR TITLE
Fix default return codes

### DIFF
--- a/curiefense/curieproxy/lua/nativeutils.lua
+++ b/curiefense/curieproxy/lua/nativeutils.lua
@@ -112,7 +112,7 @@ function nativeutils.envoy_custom_response(request_map, action_params)
     -- if not block_mode then block_mode = true end
 
     local response = {
-        [ "status" ] = "403",
+        [ "status" ] = "503",
         [ "headers"] = { ["x-curiefense"] = "response" },
         [ "reason" ] = { initiator = "undefined", reason = "undefined"},
         [ "content"] = "curiefense - request denied"

--- a/curiefense/curieproxy/rust/curiefense/src/interface.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface.rs
@@ -188,7 +188,7 @@ impl std::default::Default for Action {
             atype: ActionType::Block,
             block_mode: true,
             ban: false,
-            status: 403,
+            status: 503,
             headers: None,
             reason: serde_json::value::Value::Null,
             content: "curiefense - request denied".to_string(),
@@ -201,7 +201,7 @@ impl SimpleAction {
     pub fn from_reason(reason: String) -> Self {
         SimpleAction {
             atype: SimpleActionT::default(),
-            status: 403,
+            status: 503,
             reason,
         }
     }
@@ -272,7 +272,7 @@ impl SimpleAction {
                 Err(rr) => return Err(anyhow::anyhow!("Unparseable status: {} -> {}", sstatus, rr)),
             }
         } else {
-            403
+            503
         };
         Ok(SimpleAction {
             atype,

--- a/curiefense/curieproxy/rust/luatests/raw_requests/actions.json
+++ b/curiefense/curieproxy/rust/luatests/raw_requests/actions.json
@@ -11,7 +11,7 @@
     "response": {
       "action": "custom_response",
       "block_mode": true,
-      "status": 403,
+      "status": 503,
       "tags": [
         "all",
         "geo:united-states",

--- a/curiefense/curieproxy/rust/luatests/raw_requests/test-tag-actions.json
+++ b/curiefense/curieproxy/rust/luatests/raw_requests/test-tag-actions.json
@@ -18,7 +18,7 @@
       ],
       "action": "custom_response",
       "block_mode": true,
-      "status": 403
+      "status": 503
     },
     "name": "test action challenge",
     "headers": {
@@ -76,7 +76,7 @@
       ],
       "action": "custom_response",
       "block_mode": true,
-      "status": 403
+      "status": 503
     },
     "name": "test action default",
     "headers": {
@@ -134,7 +134,7 @@
       ],
       "action": "custom_response",
       "block_mode": true,
-      "status": 403
+      "status": 503
     },
     "name": "test action default",
     "headers": {


### PR DESCRIPTION
Default action return codes are 503, except for ACL and WAF rules that
should return 403.

Should fix #487.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>