### PR TITLE
Clean remoteaddress when logging nginx requests

### DIFF
--- a/curiefense/images/curieproxy-nginx/start.sh
+++ b/curiefense/images/curieproxy-nginx/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+rm -f /run/rsyslogd.pid
 rsyslogd -n &
 
 /usr/local/openresty/bin/openresty -g "daemon off;"


### PR DESCRIPTION
Also make the nginx container more resistant to restarts.

Should help with #485 

Signed-off-by: Simon Marechal <bartavelle@gmail.com>