### PR TITLE
Do not block flow control entries on key miss

### DIFF
--- a/curiefense/curieproxy/rust/luatests/config/json/flow-control.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/flow-control.json
@@ -147,5 +147,48 @@
         },
         "ttl": 4,
         "id": "d03dabe4b9ca"
+    },
+    {
+        "exclude": [],
+        "include": [
+            "all"
+        ],
+        "name": "Flow Control on header (same uri)",
+        "key": [
+            {
+                "headers": "test"
+            }
+        ],
+        "sequence": [
+            {
+                "method": "GET",
+                "uri": "/flowheader",
+                "cookies": {},
+                "headers": {
+                    "host": "www.example.com"
+                },
+                "args": {
+                    "step": "^1$"
+                }
+            },
+            {
+                "method": "GET",
+                "uri": "/flowheader",
+                "cookies": {},
+                "headers": {
+                    "host": "www.example.com"
+                },
+                "args": {
+                    "step": "^2$"
+                }
+            }
+        ],
+        "active": true,
+        "notes": "",
+        "action": {
+            "type": "default"
+        },
+        "ttl": 4,
+        "id": "c03dabe4b9ca"
     }
 ]

--- a/curiefense/curieproxy/rust/luatests/flows/on_header.json
+++ b/curiefense/curieproxy/rust/luatests/flows/on_header.json
@@ -1,0 +1,45 @@
+[
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/flowheader?step=2",
+      ":authority": "www.example.com"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/flowheader?step=2",
+      ":authority": "www.example.com",
+      "test": "value"
+    },
+    "delay": 0,
+    "pass": false
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/flowheader?step=1",
+      ":authority": "www.example.com",
+      "test": "value2"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "23.129.64.253",
+      ":method": "GET",
+      ":path": "/flowheader?step=2",
+      ":authority": "www.example.com",
+      "test": "value2"
+    },
+    "delay": 0,
+    "pass": true
+  }
+]


### PR DESCRIPTION
When the selector doesn't select anything, we should never block.

Shoud fix #503.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>