### PR TITLE
Make sure tags are never empty

### DIFF
--- a/curiefense/curieproxy/lua/session_nginx.lua
+++ b/curiefense/curieproxy/lua/session_nginx.lua
@@ -106,9 +106,6 @@ function session_rust_nginx.log(handle)
         req.blocked=false
     end
 
-    -- this is necessary for logstash to choose the right pipeline
-    table.insert(req.tags, "curieaccesslog")
-
     local raw_server_port = handle.var.server_port
     local raw_remote_port = handle.var.remote_port
     local server_port = tonumber(raw_server_port) or raw_server_port

--- a/curiefense/curieproxy/rust/curiefense/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/lib.rs
@@ -75,6 +75,9 @@ pub fn inspect_generic_request_map<GH: Grasshopper>(
 ) -> (Decision, Tags) {
     let mut tags = itags;
 
+    // insert the all tag here, to make sure it is always present, even in the presence of early errors
+    tags.insert("all");
+
     logs.debug(format!("Inspection starts (grasshopper active: {})", mgh.is_some()));
 
     // without grasshopper, default to being human
@@ -104,11 +107,11 @@ pub fn inspect_generic_request_map<GH: Grasshopper>(
         Some((Some(stuff), itags, iflows)) => (stuff, itags, iflows),
         Some((None, _, _)) => {
             logs.debug("Could not find a matching urlmap");
-            return (Decision::Pass, Tags::default());
+            return (Decision::Pass, tags);
         }
         None => {
             logs.debug("Something went wrong during request tagging");
-            return (Decision::Pass, Tags::default());
+            return (Decision::Pass, tags);
         }
     };
     logs.debug("request tagged");

--- a/curiefense/curieproxy/rust/curiefense/src/tagging.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/tagging.rs
@@ -69,7 +69,6 @@ fn check_subsection(rinfo: &RequestInfo, sub: &ProfilingSSection) -> bool {
 
 pub fn tag_request(is_human: bool, cfg: &Config, rinfo: &RequestInfo) -> (Tags, SimpleDecision) {
     let mut tags = Tags::default();
-    tags.insert("all");
     tags.insert_qualified("ip", &rinfo.rinfo.geoip.ipstr);
     tags.insert_qualified("geo", rinfo.rinfo.geoip.country_name.as_deref().unwrap_or("nil"));
     match rinfo.rinfo.geoip.asn {


### PR DESCRIPTION
This patch ensures the `all` tag is always present, regardless of
further errors, in particular missing urlmaps.

As a side effect, the `bot` and `human` tags are no longer ignored when
urlmaps are missing.

The nginx version does not automatically add the `curieaccesslog` tag
anymore.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>