### PR TITLE
Prevent empty tag fields for reason

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/interface.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface.rs
@@ -412,7 +412,13 @@ pub fn challenge_phase01<GH: Grasshopper>(gh: &GH, ua: &str, tags: Vec<String>) 
         atype: ActionType::Block,
         block_mode: true,
         ban: false,
-        reason: json!({"initiator": "phase01", "reason": "challenge", "tags": tags}),
+        reason: if tags.is_empty() {
+            // this happens for rate limit / flow control / tag action
+            json!({"initiator": "phase01", "reason": "challenge"})
+        } else {
+            // this only happens for acl challenges
+            json!({"initiator": "phase01", "reason": "challenge", "tags": tags})
+        },
         headers: Some(hdrs),
         status: 247,
         content,


### PR DESCRIPTION
The tag field in the reason field could be empty for challenge actions
that did not emanate from acl rules. This patch prevents the field from
being displayed if it is empty, as the lua processing would turn the
empty array into an empty object, resulting in ElasticSearch errors down
the line.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>