### PR TITLE
Fix nginx failure with unknown remote ip

### DIFF
--- a/curiefense/curieproxy/lua/session_nginx.lua
+++ b/curiefense/curieproxy/lua/session_nginx.lua
@@ -58,6 +58,9 @@ function session_rust_nginx.inspect(handle)
 end
 
 local function parse_ip_port(ipport)
+    if ipport == nil then
+        return nil, nil
+    end
     local s, _ = string.find(ipport, ":")
     if s == nil then
       return ipport, nil


### PR DESCRIPTION
The `parse_ip_port` function now doesn't kill logging when an ip is nil.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>