### PR TITLE
Fix consistency checking - ACL and WAF

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/backend/gitbackend.py
+++ b/curiefense/curieconf/server/curieconf/confserver/backend/gitbackend.py
@@ -494,15 +494,19 @@ class GitBackend(CurieBackend):
         if "wafpolicies" in docs:
             for waf_policy in docs["wafpolicies"]:
                 waf_policies.append(waf_policy["id"])
+            for waf_policy in referenced_waf_policies:
+                if waf_policy not in waf_policies:
+                    res.append(
+                        f"WAF Profile {waf_policy} is referenced but not present"
+                    )
         if "aclpolicies" in docs:
             for acl_policy in docs["aclpolicies"]:
                 acl_policies.append(acl_policy["id"])
-        for acl_policy in referenced_acl_policies:
-            if acl_policy not in acl_policies:
-                res.append(f"ACL Profile {acl_policy} is referenced but not present")
-        for waf_policy in referenced_waf_policies:
-            if waf_policy not in waf_policies:
-                res.append(f"WAF Profile {waf_policy} is referenced but not present")
+            for acl_policy in referenced_acl_policies:
+                if acl_policy not in acl_policies:
+                    res.append(
+                        f"ACL Profile {acl_policy} is referenced but not present"
+                    )
         return res
 
     def documents_list(self, config, version=None):


### PR DESCRIPTION
Fix `_documents_check_current_consistency` function - do not check `acl` and `waf` if they were just removed. If not - it is always falling to `is referenced but not present`.