### PR TITLE
Pre-commit config for python checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+    -   id: black
+        args: ["--check", "--diff"]


### PR DESCRIPTION
Adding `pre-commit` config file, so python `black` checks will be run locally before every commit .
To set up git hook do:
```
pip3 pre-commit install
pre-commit install
```

# Changelog
- added pre-commit config for python checks

Signed-off-by: Freakachoo <freakachoo.corp@gmail.com>