### PR TITLE
Add an option to upload configuration through the GUI

### DIFF
--- a/curiefense/ui/src/assets/RequestsUtils.ts
+++ b/curiefense/ui/src/assets/RequestsUtils.ts
@@ -47,7 +47,7 @@ const processRequest = (methodName: MethodNames, apiUrl: string, data: any, conf
   }
   request = request.then((response: AxiosResponse) => {
     // Toast message
-    if (successMessage) {
+    if (successMessage && response.data.ok) {
       Utils.toast(successMessage, 'is-success', undoFunction)
     }
     return response
@@ -59,7 +59,8 @@ const processRequest = (methodName: MethodNames, apiUrl: string, data: any, conf
     if (typeof onFail === 'function') {
       onFail();
     }
-    console.error( error )
+    console.error(error)
+    return {}
   })
   return request
 }

--- a/curiefense/ui/src/assets/Utils.ts
+++ b/curiefense/ui/src/assets/Utils.ts
@@ -78,7 +78,7 @@ type UploadFileParams = {
   file: File,
   callback: Function,
   dataValidator: (data: GenericObject) => boolean,
-  dataSender: Function,
+  dataSender: (uploadData: GenericObject[], fileName: string, failureMessage: string) => void,
 }
 
 const uploadFile = ({file, callback, dataValidator, dataSender}: UploadFileParams) => {
@@ -109,7 +109,6 @@ const uploadFile = ({file, callback, dataValidator, dataSender}: UploadFileParam
     }
   }
   reader.onerror = onFail
-  reader.onabort = onFail
   reader.readAsText( file )
 }
 

--- a/curiefense/ui/src/assets/__tests__/RequestsUtils.spec.ts
+++ b/curiefense/ui/src/assets/__tests__/RequestsUtils.spec.ts
@@ -12,10 +12,10 @@ describe('RequestsUtils.ts', () => {
   let postSpy: any
   let deleteSpy: any
   beforeEach(() => {
-    getSpy = jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve())
-    putSpy = jest.spyOn(axios, 'put').mockImplementation(() => Promise.resolve())
-    postSpy = jest.spyOn(axios, 'post').mockImplementation(() => Promise.resolve())
-    deleteSpy = jest.spyOn(axios, 'delete').mockImplementation(() => Promise.resolve())
+    getSpy = jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({data: {ok: true}}))
+    putSpy = jest.spyOn(axios, 'put').mockImplementation(() => Promise.resolve({data: {ok: true}}))
+    postSpy = jest.spyOn(axios, 'post').mockImplementation(() => Promise.resolve({data: {ok: true}}))
+    deleteSpy = jest.spyOn(axios, 'delete').mockImplementation(() => Promise.resolve({data: {ok: true}}))
   })
   afterEach(() => {
     jest.clearAllMocks()

--- a/curiefense/ui/src/assets/__tests__/Utils.spec.ts
+++ b/curiefense/ui/src/assets/__tests__/Utils.spec.ts
@@ -247,7 +247,7 @@ describe('Utils.ts', () => {
     let dataValidator: (data: GenericObject) => boolean
     let dataSender: (uploadData: GenericObject) => Promise<void>
     let fileData: string
-    const pauseFor = (milliseconds: number) => new Promise(resolve => setTimeout(resolve, milliseconds))
+    const pauseFor = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds))
     beforeEach(() => {
       fileData = '[{"foo": "bar"}]'
       file = new File([fileData], 'test-file.json', {lastModified: 0, type: 'application/json'})

--- a/curiefense/ui/src/assets/__tests__/Utils.spec.ts
+++ b/curiefense/ui/src/assets/__tests__/Utils.spec.ts
@@ -246,7 +246,7 @@ describe('Utils.ts', () => {
     let file: File
     let callback: Function
     let dataValidator: (data: GenericObject) => boolean
-    let dataSender: Function
+    let dataSender: (uploadData: GenericObject, fileName: string, failureMessage: string) => void
     let fileData: string
     beforeEach(() => {
       fileData = '{foo: \'bar\'}'

--- a/curiefense/ui/src/assets/__tests__/Utils.spec.ts
+++ b/curiefense/ui/src/assets/__tests__/Utils.spec.ts
@@ -4,6 +4,7 @@ import * as bulmaToast from 'bulma-toast'
 import {Options} from 'bulma-toast'
 import axios from 'axios'
 import {JSDOM} from 'jsdom'
+import {GenericObject} from '@/types'
 
 describe('Utils.ts', () => {
   describe('generateUniqueEntityName function', () => {
@@ -239,6 +240,63 @@ describe('Utils.ts', () => {
         done()
       })
     })
+  })
+
+  describe('uploadFile function', () => {
+    let file: File
+    let callback: Function
+    let dataValidator: (data: GenericObject) => boolean
+    let dataSender: Function
+    let fileData: string
+    beforeEach(() => {
+      fileData = '{foo: \'bar\'}'
+      file = new File([fileData], 'test-file.json', {lastModified: 0, type: 'application/json'});
+      // file = {
+      //   name: 'mock.json',
+      //   size: 1000,
+      //   type: 'application/json',
+      //   lastModified: 0,
+      //   webkitRelativePath: '',
+      //   arrayBuffer: Promise,
+      //   slice: Function
+      // }
+    })
+
+    test('should not throw errors if given valid input', (done) => {
+      try {
+        Utils.uploadFile({file, callback, dataValidator, dataSender})
+        done()
+      } catch (err) {
+        expect(err).not.toBeDefined()
+        done()
+      }
+    })
+
+    // test('should not log errors if given valid input', (done) => {
+    //   const originalLog = console.log
+    //   const consoleOutput: string[] = []
+    //   console.log = (output: string) => consoleOutput.push(output)
+    //   Utils.downloadFile(fileName, fileType, data)
+    //   // allow all requests to finish
+    //   setImmediate(() => {
+    //     expect(consoleOutput).toEqual([])
+    //     console.log = originalLog
+    //     done()
+    //   })
+    // })
+
+    // test('should log message when receiving unknown file type', (done) => {
+    //   const originalLog = console.log
+    //   const consoleOutput: string[] = []
+    //   console.log = (output: string) => consoleOutput.push(output)
+    //   Utils.downloadFile(fileName, 'weird string', data)
+    //   // allow all requests to finish
+    //   setImmediate(() => {
+    //     expect(consoleOutput).toContain(`Unable to download file, unknown file type`)
+    //     console.log = originalLog
+    //     done()
+    //   })
+    // })
   })
 
   describe('toast function', () => {

--- a/curiefense/ui/src/views/DocumentEditor.vue
+++ b/curiefense/ui/src/views/DocumentEditor.vue
@@ -405,14 +405,14 @@ export default Vue.extend({
 
     async loadConfigs(counterOnly?: boolean) {
       // store configs
-      let configs
-      try {
-        const response = await RequestsUtils.sendRequest({methodName: 'GET', url: 'configs/'})
-        configs = response.data
-      } catch (err) {
-        console.log('Error while attempting to get configs')
-        console.log(err)
-      }
+      const response = await RequestsUtils.sendRequest({
+        methodName: 'GET',
+        url: 'configs/',
+        onFail() {
+          console.log('Error while attempting to get configs')
+        },
+      })
+      const configs = response.data
       if (!counterOnly) {
         console.log('loaded configs: ', configs)
         this.configs = configs
@@ -548,7 +548,7 @@ export default Vue.extend({
         Utils.uploadFile({
           file: files.item(0),
           callback,
-          dataSender: async (fileData: [], fileName: string, failureMessage: string) => {
+          dataSender: async (fileData: GenericObject[], fileName: string, failureMessage: string) => {
             const {data} = await RequestsUtils.sendRequest({
               data: fileData,
               url: `configs/${this.selectedBranch}/d/${this.selectedDocType}/`,

--- a/curiefense/ui/src/views/DocumentSearch.vue
+++ b/curiefense/ui/src/views/DocumentSearch.vue
@@ -309,14 +309,14 @@ export default Vue.extend({
 
     async loadConfigs() {
       // store configs
-      let configs
-      try {
-        const response = await RequestsUtils.sendRequest({methodName: 'GET', url: 'configs/'})
-        configs = response.data
-      } catch (err) {
-        console.log('Error while attempting to get configs')
-        console.log(err)
-      }
+      const response = await RequestsUtils.sendRequest({
+        methodName: 'GET',
+        url: 'configs/',
+        onFail() {
+          console.log('Error while attempting to get configs')
+        },
+      })
+      const configs = response.data
       console.log('loaded configs: ', configs)
       this.configs = configs
       // pick first branch name as selected

--- a/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
+++ b/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
@@ -1525,6 +1525,16 @@ describe('DocumentEditor.vue', () => {
       await Vue.nextTick()
       expect(downloadFileSpy).toHaveBeenCalledWith(wantedFileName, wantedFileType, wantedFileData)
     })
+
+    // test('should attempt to upload document when upload button is clicked', async () => {
+    //   const wantedFileName = 'aclpolicies'
+    //   const wantedFileType = 'json'
+    //   const wantedFileData = aclDocs
+    //   const downloadDocButton = wrapper.find('.download-doc-button')
+    //   downloadDocButton.trigger('click')
+    //   await Vue.nextTick()
+    //   expect(downloadFileSpy).toHaveBeenCalledWith(wantedFileName, wantedFileType, wantedFileData)
+    // })
   })
 
   describe('no data', () => {

--- a/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
+++ b/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
@@ -7,7 +7,7 @@ import {shallowMount, Wrapper} from '@vue/test-utils'
 import Vue from 'vue'
 import axios from 'axios'
 import _ from 'lodash'
-import { ACLPolicy, Branch, Commit, FlowControl, RateLimit, TagRule, GenericObject, URLMap, WAFPolicy } from '@/types'
+import {ACLPolicy, Branch, Commit, FlowControl, RateLimit, TagRule, GenericObject, URLMap, WAFPolicy} from '@/types'
 
 jest.mock('axios')
 
@@ -1542,7 +1542,7 @@ describe('DocumentEditor.vue', () => {
               },
               length: 1,
             },
-          }
+          },
         }
       })
       afterEach(() => {

--- a/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
+++ b/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
@@ -7,7 +7,7 @@ import {shallowMount, Wrapper} from '@vue/test-utils'
 import Vue from 'vue'
 import axios from 'axios'
 import _ from 'lodash'
-import {ACLPolicy, Branch, Commit, FlowControl, RateLimit, TagRule, URLMap, WAFPolicy} from '@/types'
+import { ACLPolicy, Branch, Commit, FlowControl, RateLimit, TagRule, GenericObject, URLMap, WAFPolicy } from '@/types'
 
 jest.mock('axios')
 
@@ -1526,15 +1526,51 @@ describe('DocumentEditor.vue', () => {
       expect(downloadFileSpy).toHaveBeenCalledWith(wantedFileName, wantedFileType, wantedFileData)
     })
 
-    // test('should attempt to upload document when upload button is clicked', async () => {
-    //   const wantedFileName = 'aclpolicies'
-    //   const wantedFileType = 'json'
-    //   const wantedFileData = aclDocs
-    //   const downloadDocButton = wrapper.find('.download-doc-button')
-    //   downloadDocButton.trigger('click')
-    //   await Vue.nextTick()
-    //   expect(downloadFileSpy).toHaveBeenCalledWith(wantedFileName, wantedFileType, wantedFileData)
-    // })
+    describe('upload document', () => {
+      let fileData: string
+      let file: File
+      let event: GenericObject
+      beforeEach(() => {
+        fileData = '[{"foo": "bar"}]'
+        file = new File([fileData], 'test-file.json', {lastModified: 0, type: 'application/json'})
+        event = {
+          target: {
+            files: {
+              0: file,
+              item(n: number): File {
+                return event.target.files[n]
+              },
+              length: 1,
+            },
+          }
+        }
+      })
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+      test('should attempt to upload document when upload button is clicked', async () => {
+        const uploadSpy = jest.spyOn(Utils, 'uploadFile').mockImplementationOnce(() => Promise.resolve({response: {data: {ok: true}}, uploadData: []}))
+        await (wrapper.vm as any).uploadDoc(event)
+        expect(uploadSpy).toHaveBeenCalledTimes(1)
+        expect((wrapper.vm as any).isUploading).toBeFalsy()
+        expect((wrapper.find('.file-input').element as HTMLInputElement).value).toBeFalsy()
+      })
+      test('should display error if upload failed', async () => {
+        const toastOutput: string[] = []
+        jest.spyOn(Utils, 'uploadFile').mockImplementationOnce(() => Promise.resolve({response: {data: {ok: false}}, uploadData: []}))
+        jest.spyOn(Utils, 'toast').mockImplementationOnce((message) => toastOutput.push(message as string))
+        await (wrapper.vm as any).uploadDoc(event)
+        expect(toastOutput).toContain(`Failed while attempting to upload ${file.name}:<br />Invalid file`)
+      })
+      test('should detect given file as invalid', async () => {
+        jest.spyOn(Utils, 'uploadFile').mockImplementationOnce((file, sender, validator) => {
+          expect(validator(JSON.parse(fileData)[0])).toBeFalsy()
+          return Promise.resolve({response: {data: {ok: true}}, uploadData: []})
+        })
+        await (wrapper.vm as any).uploadDoc(event)
+        expect((wrapper.vm as any).isUploading).toBeFalsy()
+      })
+    })
   })
 
   describe('no data', () => {


### PR DESCRIPTION
We would like to give the user the ability to upload configuration through the GUI
The new feature will act in the same manner as the Download buttons around the system, but instead of downloading a JSON configuration file, it would upload the configuration

In every location where we have a Download button, add a new button called "Upload" next to it with the functionality described above. The uploaded data would override the existing data whenever uploaded

![screenshot-localhost_8080-2021 08 10-17_09_12](https://user-images.githubusercontent.com/86227793/128882071-88e2a765-f800-4175-a59a-1e82483c33d7.png)
