### PR TITLE
Always set directremoteaddress in ngx lua

### DIFF
--- a/curiefense/curieproxy/lua/session_nginx.lua
+++ b/curiefense/curieproxy/lua/session_nginx.lua
@@ -121,6 +121,7 @@ function session_rust_nginx.log(handle)
       remoteaddressport=remote_port,
       directlocaladdress=handle.var.server_addr,
       directremoteaddressport=remote_port,
+      directremoteaddress=handle.var.remote_addr,
     }
 
     req.upstream = {}


### PR DESCRIPTION
If not, it is set as an empty string in curielogger, which prevents
logging from working.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>