### PR TITLE
Prevent ELK from fail on GitHub Actions

### DIFF
--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      # Some VM settings to help ELK keep up, according to https://github.com/elastic/elastic-github-actions/tree/master/elasticsearch
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
       - name: Run tests
         run: |
             export BASEDIR=$(git rev-parse --show-toplevel)

--- a/.github/workflows/e2e-minikube-filebeat.yml
+++ b/.github/workflows/e2e-minikube-filebeat.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      # Some VM settings to help ELK keep up, according to https://github.com/elastic/elastic-github-actions/tree/master/elasticsearch
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.3.0
         with:

--- a/.github/workflows/e2e-minikube-fluentd.yml
+++ b/.github/workflows/e2e-minikube-fluentd.yml
@@ -28,6 +28,14 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: "--memory='3Gi' --addons=ingress"
 
+      # Some VM settings to help ELK keep up, according to https://github.com/elastic/elastic-github-actions/tree/master/elasticsearch
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
       - name: Interact with the cluster
         run: |
             export BASEDIR=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Sometimes on GitHub actions ELK is falling and prevents tests to finish.
Here is the possible solution: https://github.com/elastic/elastic-github-actions/tree/master/elasticsearch
Let's add it and hope it helps.

# Change log 
Add sysctl settings for GitHub actions VMs to help ELK not to fail
