### PR TITLE
Http request methods dropdown in flow control

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/json/flow-control.schema
+++ b/curiefense/curieconf/server/curieconf/confserver/json/flow-control.schema
@@ -53,7 +53,19 @@
     "sequence": {
       "type": "array",
       "title": "Sequence",
-      "description": "Array of sections describing steps of restricted flow"
+      "description": "Array of sections describing steps of restricted flow",
+      "items": {
+        "type": "object",
+        "properties": {
+          "method": { "enum": ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "TRACE", "OPTIONS", "PATCH"] },
+          "uri": { "type": "string" },
+          "cookies": { "type": "object" },
+          "headers": { "type": "object" },
+          "args": { "type": "object" }
+        },
+        "required": ["method", "uri"]
+      },
+      "uniqueItems": true
     }
   },
   "additionalProperties": true,

--- a/curiefense/ui/src/doc-editors/FlowControlEditor.vue
+++ b/curiefense/ui/src/doc-editors/FlowControlEditor.vue
@@ -154,11 +154,15 @@
                         Method
                       </td>
                       <td colspan="2">
-                        <div class="control is-fullwidth">
-                          <input class="input is-small method-entry-input"
-                                 title="Method"
-                                 v-model="sequenceItem.method"
-                                 @input="emitDocUpdate"/>
+                        <div class="select is-small is-fullwidth">
+                          <select v-model="sequenceItem.method"
+                                  title="Method"
+                                  class="select method-entry-input"
+                                  @change="emitDocUpdate">
+                            <option v-for="method in httpRequestMethods" :key="method" :value="method">
+                              {{ method }}
+                            </option>
+                          </select>
                         </div>
                       </td>
                       <td class="width-80px"></td>
@@ -310,9 +314,9 @@
                 </div>
                 <div v-if="localDoc.sequence.length > 1 && sequenceIndex !== localDoc.sequence.length - 1"
                      class="control is-expanded relation-wrapper">
-              <span class="tag is-small is-relative">
-                THEN
-              </span>
+                  <span class="tag is-small is-relative">
+                    THEN
+                  </span>
                 </div>
               </div>
               <button class="button is-small new-sequence-button"
@@ -336,6 +340,7 @@ import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import DatasetsUtils from '@/assets/DatasetsUtils.ts'
 import Vue from 'vue'
 import {ArgsCookiesHeadersType, FlowControl, IncludeExcludeType, LimitOptionType, LimitRuleType} from '@/types'
+import {httpRequestMethods} from '@/types/const'
 import {Dictionary} from 'vue-router/types/router'
 
 export default Vue.extend({
@@ -358,7 +363,7 @@ export default Vue.extend({
       addNewTagColName: null,
       titles: DatasetsUtils.titles,
       defaultSequenceItem: {
-        'method': 'GET',
+        'method': httpRequestMethods[0],
         'uri': '/',
         'cookies': {},
         'headers': {
@@ -378,6 +383,7 @@ export default Vue.extend({
         name: '',
         value: '',
       },
+      httpRequestMethods,
     }
   },
 

--- a/curiefense/ui/src/doc-editors/__tests__/FlowControlEditor.spec.ts
+++ b/curiefense/ui/src/doc-editors/__tests__/FlowControlEditor.spec.ts
@@ -5,10 +5,10 @@ import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import {beforeEach, describe, expect, test, jest} from '@jest/globals'
 import {shallowMount, Wrapper} from '@vue/test-utils'
 import Vue from 'vue'
-
-jest.mock('axios')
 import axios from 'axios'
 import {FlowControl} from '@/types'
+
+jest.mock('axios')
 
 describe('FlowControlEditor.vue', () => {
   let docs: FlowControl[]

--- a/curiefense/ui/src/types/const.ts
+++ b/curiefense/ui/src/types/const.ts
@@ -1,0 +1,3 @@
+export const httpRequestMethods = [
+  'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'TRACE', 'OPTIONS', 'PATCH',
+] as const

--- a/curiefense/ui/src/types/index.d.ts
+++ b/curiefense/ui/src/types/index.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-
+import {httpRequestMethods} from './const'
 declare module CuriefenseClient {
 
   type GenericObject = { [key: string]: any }
@@ -151,6 +151,8 @@ declare module CuriefenseClient {
     pairwith: LimitOptionType
   }
 
+  type HttpRequestMethods = typeof httpRequestMethods[number]
+
   type FlowControl = {
     id: string
     name: string
@@ -165,7 +167,7 @@ declare module CuriefenseClient {
       args: GenericObject
       cookies: GenericObject
       headers: GenericObject
-      method: string
+      method: HttpRequestMethods
       uri: string
     }[]
   }


### PR DESCRIPTION
As described here: https://github.com/curiefense/curiefense/issues/504

We'd like to change the Flow Control <Method> field to a dropdown, which would accept only the known http request method names
In addition, we'll have to change the API schema to accept only these method names in the <Method> field

<img width="1163" alt="Screen Shot 2021-08-23 at 13 56 14" src="https://user-images.githubusercontent.com/86227793/130437301-427635ac-ede5-4bd3-9b3a-04c70584cf17.png">
