### PR TITLE
Fix google crc version

### DIFF
--- a/curiefense/curieconf/utils/setup.py
+++ b/curiefense/curieconf/utils/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=["curieconf.utils"],
     install_requires=[
         "wheel",
+        "google-crc32c==1.1.2",
         "cloudstorage [amazon, google, local]",
         "pydash==5.0.2",
     ],


### PR DESCRIPTION
Since google-crc32c version 1.1.3 release, there was a fail to install the package when starting curietasker and curiesync containers.
Changed google-crc32c package to be fixed on version 1.1.2

Used to give this error:
```
Installing collected packages: inflection, six, python-dateutil, typing-extensions, botocore-stubs, mypy-boto3-s3, boto3-stubs, jmespath, urllib3, botocore, s3transfer, boto3, certifi, charset-normalizer, idna, requests, cachetools, pyasn1, pyasn1-modules, rsa, google-auth, protobuf, googleapis-common-protos, google-api-core, google-cloud-core, google-crc32c, google-resumable-media, google-cloud-storage, filelock, itsdangerous, cloudstorage, pydash, curieconf-utils
  Running setup.py install for google-crc32c: started
    Running setup.py install for google-crc32c: finished with status 'error'
    Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-7b8eu3n2/google-crc32c/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-ur9tsttp/install-record.txt --single-version-externally-managed --compile:
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.7
    creating build/lib.linux-x86_64-3.7/google_crc32c
    copying src/google_crc32c/python.py -> build/lib.linux-x86_64-3.7/google_crc32c
    copying src/google_crc32c/__init__.py -> build/lib.linux-x86_64-3.7/google_crc32c
    copying src/google_crc32c/__config__.py -> build/lib.linux-x86_64-3.7/google_crc32c
    copying src/google_crc32c/cext.py -> build/lib.linux-x86_64-3.7/google_crc32c
    copying src/google_crc32c/_checksum.py -> build/lib.linux-x86_64-3.7/google_crc32c
    running build_ext
    building 'google_crc32c._crc32c' extension
    creating build/temp.linux-x86_64-3.7
    creating build/temp.linux-x86_64-3.7/src
    creating build/temp.linux-x86_64-3.7/src/google_crc32c
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.7m -c src/google_crc32c/_crc32c.c -o build/temp.linux-x86_64-3.7/src/google_crc32c/_crc32c.o
    unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    
    ----------------------------------------
Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-7b8eu3n2/google-crc32c/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-ur9tsttp/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-install-7b8eu3n2/google-crc32c/
The command '/bin/sh -c cd /curieconf-utils ; pip3 install --no-cache-dir .' returned a non-zero code: 1
```