### PR TITLE
Freeze docker images versions

### DIFF
--- a/curiefense/images/confserver/Dockerfile
+++ b/curiefense/images/confserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uwsgi-nginx-flask:python3.8
+FROM tiangolo/uwsgi-nginx-flask:python3.8-2021-09-08
 
 RUN ln -sf /bootstrap/initial-bucket-export.conf /etc/supervisor/conf.d/initial-bucket-export.conf
 RUN ln -sf /init/nginx.conf /etc/nginx/conf.d/nginx.conf

--- a/curiefense/images/curiefense-nginx-ingress/Dockerfile
+++ b/curiefense/images/curiefense-nginx-ingress/Dockerfile
@@ -1,7 +1,7 @@
 ARG RUSTBIN_TAG=latest
 FROM curiefense/curiefense-rustbuild-focal:${RUSTBIN_TAG} AS rustbin
 FROM docker.io/nginx/nginx-ingress:1.11.3 as nginx-ingress
-FROM docker.io/openresty/openresty:focal as openresty
+FROM docker.io/openresty/openresty:1.19.9.1-1-focal as openresty
 
 USER root
 RUN groupadd --system --gid 101 nginx \

--- a/curiefense/images/curielogger/Dockerfile
+++ b/curiefense/images/curielogger/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1-alpine as builder
+FROM golang:1.17.1-alpine3.14 as builder
 
 WORKDIR /app
 COPY curielogger .

--- a/curiefense/images/curieproxy-envoy/Dockerfile
+++ b/curiefense/images/curieproxy-envoy/Dockerfile
@@ -1,7 +1,7 @@
 ARG RUSTBIN_TAG=latest
 FROM curiefense/curiefense-rustbuild-bionic:${RUSTBIN_TAG} AS rustbin
 FROM curiefense/envoy-cf:0250ad715e8c0463d0d4389cbfab340bc7dd7587 AS envoy-cf
-FROM envoyproxy/envoy:v1.16-latest
+FROM envoyproxy/envoy:v1.16.5
 
 RUN apt-get update && \
     apt-get -qq -y --no-install-recommends install jq luarocks libpcre2-dev libgeoip-dev \

--- a/curiefense/images/curieproxy-nginx/Dockerfile
+++ b/curiefense/images/curieproxy-nginx/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUSTBIN_TAG=latest
 FROM curiefense/curiefense-rustbuild-focal:${RUSTBIN_TAG} AS rustbin
-FROM docker.io/openresty/openresty:focal
+FROM docker.io/openresty/openresty:1.19.9.1-1-focal
 COPY conf.d /etc/nginx/conf.d
 COPY curieproxy/lua /lua
 COPY curieproxy/lua/shared-objects/*.so /usr/local/lib/lua/5.1/

--- a/curiefense/images/prometheus/Dockerfile
+++ b/curiefense/images/prometheus/Dockerfile
@@ -1,10 +1,10 @@
-FROM prom/prometheus
+FROM prom/prometheus:v2.30.1
 COPY prometheus.yml /etc/prometheus/prometheus.yml
 ENTRYPOINT [ "/bin/prometheus" ]
-CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \ 
-              "--storage.tsdb.path=/prometheus", \ 
-              "--web.console.libraries=/usr/share/prometheus/console_libraries", \ 
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+              "--storage.tsdb.path=/prometheus", \
+              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
               "--web.console.templates=/usr/share/prometheus/consoles", \
               "--storage.tsdb.retention.time=200h", \
-              "--web.enable-lifecycle" ] 
+              "--web.enable-lifecycle" ]
 

--- a/curiefense/images/redis/Dockerfile
+++ b/curiefense/images/redis/Dockerfile
@@ -1,3 +1,3 @@
-FROM redis
+FROM redis:6.2.5
 COPY redis.conf /usr/local/etc/redis/redis.conf
 CMD redis-server /usr/local/etc/redis/redis.conf

--- a/curiefense/images/uiserver/Dockerfile
+++ b/curiefense/images/uiserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM node as builder
+FROM node:14.18.0 as builder
 
 COPY ui /ui
 WORKDIR /ui


### PR DESCRIPTION
Last days there was an issue with `confserver`. The used image `tiangolo/uwsgi-nginx-flask:python3.8` was suddenly updated on hub.docker.com and started to crush.
While working every 30 seconds it fired those logs:
```
confserver       | 2021-09-27 09:14:58,822 INFO exited: initial-bucket-export (exit status 0; expected)
confserver       | 2021-09-27 09:14:58,823 WARN received SIGTERM indicating exit request
confserver       | 2021-09-27 09:14:58,823 INFO waiting for nginx, uwsgi, quit_on_failure to die
confserver       | Mon Sep 27 09:14:58 2021 - graceful shutdown triggered...
```
and shut down/restarted the `confserver`. 

Let's freeze docker images versions when some images was updated. More than that this is a good practice to use static versions of modules and docker images.
