### PR TITLE
filebeat: ignore JSON decoding errors

### DIFF
--- a/deploy/filebeat/filebeat.yml
+++ b/deploy/filebeat/filebeat.yml
@@ -33,3 +33,4 @@ setup.template:
   json.enabled: true
   json.path: "/usr/share/filebeat/template.json"
   json.name: "curieaccesslog"
+  json.ignore_decoding_error: true


### PR DESCRIPTION
When a log line that is not valid JSON is emitted, filebeat stops
processing the file, and logs are effectively not collected anymore.

The "stdout" output module of curielogger itself generates log lines
whose "log" field contains invalid json, such as:

```
{"log":"time=\"2021-10-02T04:11:04Z\" level=info msg=\"stdout driver started\"\n","stream":"stderr","time":"2021-10-02T04:11:04.493656024Z"}
{"log":"time=\"2021-10-02T04:11:04Z\" level=info msg=\"Prometheus exporter listening on 2112\"\n","stream":"stderr","time":"2021-10-02T04:11:04.493711981Z"}
```

Signed-off-by: Xavier <xavier@reblaze.com>