### PR TITLE
Convert the ngx image to bionic

### DIFF
--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -19,6 +19,7 @@ GITTAG="$(git describe --tag --long --dirty)"
 DOCKER_DIR_HASH="$(git rev-parse --short=12 HEAD:curiefense)"
 DOCKER_TAG="${DOCKER_TAG:-$GITTAG-$DOCKER_DIR_HASH}"
 STOP_ON_FAIL=${STOP_ON_FAIL:-yes}
+RUST_DISTROS=(bionic)
 
 if [ -n "$TESTING" ]; then
     IMAGES=("$TESTING")
@@ -38,13 +39,13 @@ then
     echo "with tag : $DOCKER_TAG"
     echo "-------"
 
-    for distro in bionic focal
+    for distro in "${RUST_DISTROS[@]}"
     do
-            image=curiefense-rustbuild-${distro}
+            image="curiefense-rustbuild-${distro}"
             IMG=${REPO}/${image}
             echo "=================== $IMG:$DOCKER_TAG ====================="
             if tar -C curiefense-rustbuild -ch --exclude='.*/target' --exclude='.*/ctarget' . \
-                    | docker build --build-arg UBUNTU_VERSION=${distro} -t "$IMG:$DOCKER_TAG" -; then
+                    | docker build --build-arg UBUNTU_VERSION="${distro}" -t "$IMG:$DOCKER_TAG" -; then
                 STB="ok"
                 if [ -n "$PUSH" ]; then
                     if docker push "$IMG:$DOCKER_TAG"; then

--- a/curiefense/images/curiefense-nginx-ingress/Dockerfile
+++ b/curiefense/images/curiefense-nginx-ingress/Dockerfile
@@ -1,7 +1,7 @@
 ARG RUSTBIN_TAG=latest
-FROM curiefense/curiefense-rustbuild-focal:${RUSTBIN_TAG} AS rustbin
+FROM curiefense/curiefense-rustbuild-bionic:${RUSTBIN_TAG} AS rustbin
 FROM docker.io/nginx/nginx-ingress:1.11.3 as nginx-ingress
-FROM docker.io/openresty/openresty:1.19.9.1-1-focal as openresty
+FROM docker.io/openresty/openresty:1.19.9.1-1-bionic as openresty
 
 USER root
 RUN groupadd --system --gid 101 nginx \
@@ -10,14 +10,14 @@ RUN groupadd --system --gid 101 nginx \
 RUN apt-get update \
     && apt-get install -y \
         libcap2-bin \
-        libhyperscan5 \
+        libhyperscan4 \
         rsyslog \
-	python3-pip \
+        python3-pip \
         python3-setuptools \
         python3-wheel \
         python3-magic \
-	python3-xattr \
-	python3-cffi \
+        python3-xattr \
+        python3-cffi \
         python3-netifaces \
     && rm -rf /var/lib/apt/lists/*
 

--- a/curiefense/images/curieproxy-nginx/Dockerfile
+++ b/curiefense/images/curieproxy-nginx/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUSTBIN_TAG=latest
-FROM curiefense/curiefense-rustbuild-focal:${RUSTBIN_TAG} AS rustbin
-FROM docker.io/openresty/openresty:1.19.9.1-1-focal
+FROM curiefense/curiefense-rustbuild-bionic:${RUSTBIN_TAG} AS rustbin
+FROM docker.io/openresty/openresty:1.19.9.1-1-bionic
 COPY conf.d /etc/nginx/conf.d
 COPY curieproxy/lua /lua
 COPY curieproxy/lua/shared-objects/*.so /usr/local/lib/lua/5.1/
@@ -8,7 +8,7 @@ COPY --from=rustbin /root/curiefense.so /usr/local/lib/lua/5.1/
 
 COPY curieproxy/config /bootstrap-config/config
 
-RUN apt-get update && apt-get install -y libhyperscan5 rsyslog
+RUN apt-get update && apt-get install -y libhyperscan4 rsyslog
 RUN mkdir /config && chmod a+rwxt /config
 RUN openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=fr/O=curiefense/CN=testsystem" -keyout /etc/ssl/certificate.key -out /etc/ssl/certificate.crt
 


### PR DESCRIPTION
Once nginx-ingress too is converted, we will be able to build only one
Rust.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>