### PR TITLE
Switch from restplus to restx

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/v1/api.py
+++ b/curiefense/curieconf/server/curieconf/confserver/v1/api.py
@@ -4,7 +4,7 @@ import jsonschema
 jsonschema.Draft4Validator = jsonschema.Draft3Validator
 
 from flask import Blueprint, request, current_app, abort, make_response
-from flask_restplus import Resource, Api, fields, marshal, reqparse
+from flask_restx import Resource, Api, fields, marshal, reqparse
 from collections import defaultdict
 import datetime
 from curieconf import utils

--- a/curiefense/curieconf/server/curieconf/confserver/v2/api.py
+++ b/curiefense/curieconf/server/curieconf/confserver/v2/api.py
@@ -4,7 +4,7 @@ import jsonschema
 jsonschema.Draft4Validator = jsonschema.Draft3Validator
 
 from flask import Blueprint, request, current_app, abort, make_response
-from flask_restplus import Resource, Api, fields, marshal, reqparse
+from flask_restx import Resource, Api, fields, marshal, reqparse
 from curieconf import utils
 from curieconf.utils import cloud
 import requests

--- a/curiefense/curieconf/server/setup.py
+++ b/curiefense/curieconf/server/setup.py
@@ -27,7 +27,7 @@ setup(
         "flask",
         "flask_cors",
         "flask_pymongo",
-        "flask-restplus",
+        "flask-restx",
         "werkzeug==0.16.1",
         "gitpython",
         "colorama",

--- a/curiefense/curieconf/test/test_utils.py
+++ b/curiefense/curieconf/test/test_utils.py
@@ -3,7 +3,7 @@ from curieconf import utils
 import json
 import codecs
 import base64
-from flask_restplus import fields, model
+from flask_restx import fields, model
 
 binvec_hex = (
     "b70a1da09a4998bd56b083d76bf528053c9b924bbb07168792151a5a177bbaa232949a8600bcb2"

--- a/curiefense/curieconf/utils/curieconf/utils/__init__.py
+++ b/curiefense/curieconf/utils/curieconf/utils/__init__.py
@@ -4,7 +4,7 @@ import base64
 import json
 
 import pydash
-from flask_restplus import fields
+from flask_restx import fields
 
 DOCUMENTS_PATH = {
     "ratelimits": "config/json/limits.json",

--- a/curiefense/curieconf/utils/setup.py
+++ b/curiefense/curieconf/utils/setup.py
@@ -15,9 +15,9 @@ setup(
         "minio==6.0.2",
         "cloudstorage [amazon, google, local, minio]==0.10.1",
         "pydash==5.0.2",
-        "flask==1.1.2",
-        "flask-restplus==0.13.0",
-        "werkzeug==0.16.1",
+        "flask>=1.1.2",
+        "flask-restx",
+        "werkzeug>=0.16.1",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/curiefense/images/grafana/Dockerfile
+++ b/curiefense/images/grafana/Dockerfile
@@ -1,3 +1,3 @@
 FROM grafana/grafana:7.5.12
 
-COPY --chown=grafana:grafana provisioning/datasources/* /etc/grafana/provisioning/datasources/
+COPY --chown=grafana:root provisioning/datasources/* /etc/grafana/provisioning/datasources/


### PR DESCRIPTION
restplus has been unmaintained for a while and restx is a drop-in replacement for it.

fixes #645

Signed-off-by: Flavio Percoco <flavio@reblaze.com>