### PR TITLE
Validate Ban Actions

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/limit.rs
@@ -138,9 +138,12 @@ pub fn limit_check(
         if is_banned(&mut redis, &key) {
             logs.debug("is banned!");
             tags.insert(&limit.name);
-            // Take the first threshold because the `ban` is making sense only if it has the
-            // highest limit (so it is will be the first one in the desc ordered list).
-            return limit_react(logs, tags, &mut redis, limit, &limit.thresholds[0], key);
+            let ban_threshold: &LimitThreshold = limit
+                .thresholds
+                .iter()
+                .find(|t| matches!(t.action.atype, SimpleActionT::Ban(_, _)))
+                .unwrap_or(&limit.thresholds[0]);
+            return limit_react(logs, tags, &mut redis, limit, ban_threshold, key);
         }
 
         let pairvalue = limit.pairwith.as_ref().and_then(|sel| select_string(reqinfo, sel));

--- a/curiefense/curieproxy/rust/luatests/config/json/limits.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/limits.json
@@ -223,9 +223,9 @@
         }
     },
     {
-        "id": "limitmiltithreshold",
+        "id": "limitmultithreshold",
         "name": "First tag then ban",
-        "description": "Multiple thresholds",
+        "description": "Multiple thresholds. The last threshold to check that ban works even if it doesn't have the highest limit.",
         "timeframe": "4",
         "thresholds": [
             {
@@ -244,6 +244,12 @@
                             "type": "default"
                         }
                     }
+                }
+            },
+            {
+                "limit": "6",
+                "action": {
+                    "type": "default"
                 }
             }
         ],

--- a/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
@@ -114,20 +114,7 @@
                 "content_filter_profile": "__default__",
                 "content_filter_active": false,
                 "limit_ids": [
-                    "limitmiltithreshold"
-                ]
-            },
-            {
-                "match": "^/limits/multithreshold",
-                "name": "limits multiple thresholds",
-                "acl_profile": "__default__",
-                "waf_profile": "__default__",
-                "acl_active": true,
-                "waf_active": true,
-                "content_filter_profile": "__default__",
-                "content_filter_active": false,
-                "limit_ids": [
-                    "limitmiltithreshold"
+                    "limitmultithreshold"
                 ]
             },
             {

--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -116,8 +116,8 @@ do
 done
 
 
-if [ -n "$TESTING" ]; then
-    echo "To deploy this test image, export \"TESTING=$TESTING\" before running deploy.sh or docker-compose up"
+if [ -n "$TESTIMG" ]; then
+    echo "To deploy this test image, export \"TESTIMG=$TESTIMG\" before running deploy.sh or docker-compose up"
     echo "To choose a docker tag for all other images, also export DOCKER_TAG"
     echo "Docker tag of the current working directory is:"
     echo "export DOCKER_TAG=$OTHER_IMAGES_DOCKER_TAG"

--- a/curiefense/ui/src/doc-editors/RateLimitsEditor.vue
+++ b/curiefense/ui/src/doc-editors/RateLimitsEditor.vue
@@ -98,7 +98,7 @@
                             type="text"
                             title="A number of requests"
                             placeholder="A number of requests"
-                            @change="updateThresholdOption($event, index)"
+                            @change="emitDocUpdate"
                             v-model="threshold.limit">
                     </div>
                     <div class="button-wrapper-column column">
@@ -118,7 +118,7 @@
                   </div>
                   <response-action :action.sync="threshold.action"
                                   label-separated-line
-                                  @update:action="updateThresholdOption($event, index)"/>
+                                  @update:action="emitDocUpdate"/>
                 </div>
                 <a title="Add new threshold"
                    class="is-text is-small is-size-7 ml-3 add-threshold-button"
@@ -471,10 +471,6 @@ export default Vue.extend({
       if (this.localDoc.thresholds.length > 1) {
         this.localDoc.thresholds.splice(index, 1)
       }
-      this.emitDocUpdate()
-    },
-
-    updateThresholdOption(option: OptionObject, index: number) {
       this.emitDocUpdate()
     },
 

--- a/curiefense/ui/src/doc-editors/RateLimitsEditor.vue
+++ b/curiefense/ui/src/doc-editors/RateLimitsEditor.vue
@@ -98,7 +98,7 @@
                             type="text"
                             title="A number of requests"
                             placeholder="A number of requests"
-                            @change="emitDocUpdate"
+                            @change="updateThresholdOption($event, index)"
                             v-model="threshold.limit">
                     </div>
                     <div class="button-wrapper-column column">
@@ -118,7 +118,7 @@
                   </div>
                   <response-action :action.sync="threshold.action"
                                   label-separated-line
-                                  @update:action="emitDocUpdate"/>
+                                  @update:action="updateThresholdOption($event, index)"/>
                 </div>
                 <a title="Add new threshold"
                    class="is-text is-small is-size-7 ml-3 add-threshold-button"
@@ -129,6 +129,10 @@
                    @keypress.enter="addThreshold()">
                   New threshold
                 </a>
+                <p class="has-text-danger is-size-7 ml-3 mt-3 only-one-ban"
+                   v-if="!onlyOneBanAction">
+                  Can't be more than one Ban action.
+                </p>
               </div>
             </div>
             <div class="column is-7">
@@ -351,6 +355,7 @@ import {
   RateLimit,
   SecurityPolicy,
   SecurityPolicyEntryMatch,
+  ThresholdActionPair,
 } from '@/types'
 import {Dictionary} from 'vue-router/types/router'
 import DatasetsUtils from '@/assets/DatasetsUtils'
@@ -410,6 +415,13 @@ export default Vue.extend({
       },
     },
 
+    onlyOneBanAction(): Boolean {
+      const counts = _.countBy(this.localDoc.thresholds, (threshold) => {
+        return threshold.action.type
+      })
+      return _.get(counts, 'ban', 0) <= 1
+    },
+
     newSecurityPolicyConnections(): SecurityPolicy[] {
       return this.securityPolicies.filter((securityPolicy) => {
         return !securityPolicy.map.every((securityPolicyEntry) => {
@@ -451,7 +463,7 @@ export default Vue.extend({
     },
 
     addThreshold() {
-      this.localDoc.thresholds.push({limit: '', action: {type: 'default'}})
+      this.localDoc.thresholds.push({limit: '', action: {type: 'default'}} as ThresholdActionPair)
       this.emitDocUpdate()
     },
 
@@ -459,6 +471,10 @@ export default Vue.extend({
       if (this.localDoc.thresholds.length > 1) {
         this.localDoc.thresholds.splice(index, 1)
       }
+      this.emitDocUpdate()
+    },
+
+    updateThresholdOption(option: OptionObject, index: number) {
       this.emitDocUpdate()
     },
 

--- a/curiefense/ui/src/types/index.d.ts
+++ b/curiefense/ui/src/types/index.d.ts
@@ -45,8 +45,8 @@ declare module CuriefenseClient {
   }
 
   type ThresholdActionPair = {
-    limit?: string
-    action?: ResponseActionType
+    limit: string
+    action: ResponseActionType
   }
 
   type ResponseActionType = {


### PR DESCRIPTION
# Changelog
- Validate Ban that rate limit can have only one Ban action
- Search Ban action before applying in rust code 
- Fix TESTING to TESTIMG in build script
- Client-side validation - only one Ban action can be selected
![image](https://user-images.githubusercontent.com/5842747/147412779-221aabdf-4a2a-4428-8d72-6cdad9c5a2ce.png)

