### PR TITLE
Add property pairwith to rate limit schemas

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/v1/json/rate-limits.schema
+++ b/curiefense/curieconf/server/curieconf/confserver/v1/json/rate-limits.schema
@@ -51,6 +51,15 @@
           "type": "array",
           "title": "Included tags",
           "description": "Tags describing requests to include in the rate limit rule"
+        },
+        "pairwith": {
+          "type": "object",
+          "patternProperties": {
+            "^(self|headers|cookies|args|attrs)$": {
+              "type": "string"
+            }
+          },
+          "description": "Event option, changing the meaning of the Rate Limit"
         }
     },
     "additionalProperties": false,

--- a/curiefense/curieconf/server/curieconf/confserver/v2/json/rate-limits.schema
+++ b/curiefense/curieconf/server/curieconf/confserver/v2/json/rate-limits.schema
@@ -63,6 +63,15 @@
           "type": "array",
           "title": "Included tags",
           "description": "Tags describing requests to include in the rate limit rule"
+        },
+        "pairwith": {
+          "type": "object",
+          "patternProperties": {
+            "^(self|headers|cookies|args|attrs)$": {
+              "type": "string"
+            }
+          },
+          "description": "Event option, changing the meaning of the Rate Limit"
         }
     },
     "additionalProperties": false,


### PR DESCRIPTION
# Changelog
- added property `pairwith` to rate limit schemas