### PR TITLE
Let multiple limits work at the same time

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/limit.rs
@@ -130,7 +130,9 @@ pub fn limit_check(
         }
 
         let key = match build_key(security_policy_name, reqinfo, limit) {
-            None => return SimpleDecision::Pass,
+            // if we can't build the key, it usually means that a header is missing.
+            // If that is the case, we continue to the next limit.
+            None => continue,
             Some(k) => k,
         };
         logs.debug(format!("limit={:?} key={}", limit, key));

--- a/curiefense/curieproxy/rust/luatests/config/json/limits.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/limits.json
@@ -201,6 +201,50 @@
         }
     },
     {
+        "id": "mlimitA",
+        "name": "Multilimit test A",
+        "description": ":)",
+        "timeframe": "5",
+        "thresholds": [{
+            "limit": "2",
+            "action": {
+                "type": "default"
+            }
+        }],
+        "include": [],
+        "exclude": [],
+        "key": [
+            {
+                "headers": "h1"
+            }
+        ],
+        "pairwith": {
+            "self": "self"
+        }
+    },
+    {
+        "id": "mlimitB",
+        "name": "Multilimit test B",
+        "description": ":)",
+        "timeframe": "5",
+        "thresholds": [{
+            "limit": "3",
+            "action": {
+                "type": "default"
+            }
+        }],
+        "include": [],
+        "exclude": [],
+        "key": [
+            {
+                "headers": "h2"
+            }
+        ],
+        "pairwith": {
+            "self": "self"
+        }
+    },
+    {
         "id": "4d1d9d405fc9",
         "name": "Limit per method",
         "description": ":)",

--- a/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
@@ -158,6 +158,18 @@
                 ]
             },
             {
+                "name": "multilimit",
+                "match": "/limits/multi",
+                "acl_profile": "__default__",
+                "acl_active": true,
+                "content_filter_profile": "__default__",
+                "content_filter_active": true,
+                "limit_ids": [
+                    "mlimitA",
+                    "mlimitB"
+                ]
+            },
+            {
                 "match": "/",
                 "name": "default",
                 "acl_profile": "__default__",

--- a/curiefense/curieproxy/rust/luatests/ratelimit/test-multiple-limits.json
+++ b/curiefense/curieproxy/rust/luatests/ratelimit/test-multiple-limits.json
@@ -1,0 +1,106 @@
+[
+  {
+    "desc": "Testing with multiple limits",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "45.85.12.8",
+      ":method": "GET",
+      ":path": "/limits/multi",
+      ":authority": "localhost:30081",
+      "h1": "A"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "desc": "Testing with multiple limits",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "45.85.12.8",
+      ":method": "GET",
+      ":path": "/limits/multi",
+      ":authority": "localhost:30081",
+      "h2": "A"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "desc": "Testing with multiple limits",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "45.85.12.8",
+      ":method": "GET",
+      ":path": "/limits/multi",
+      ":authority": "localhost:30081",
+      "h1": "A"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "desc": "Testing with multiple limits",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "45.85.12.8",
+      ":method": "GET",
+      ":path": "/limits/multi",
+      ":authority": "localhost:30081",
+      "h2": "A"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "desc": "Testing with multiple limits",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "45.85.12.8",
+      ":method": "GET",
+      ":path": "/limits/multi",
+      ":authority": "localhost:30081",
+      "h1": "A"
+    },
+    "delay": 0,
+    "pass": false
+  },
+  {
+    "desc": "Testing with multiple limits",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "45.85.12.8",
+      ":method": "GET",
+      ":path": "/limits/multi",
+      ":authority": "localhost:30081",
+      "h2": "A"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "desc": "Testing with multiple limits",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "45.85.12.8",
+      ":method": "GET",
+      ":path": "/limits/multi",
+      ":authority": "localhost:30081",
+      "h1": "A"
+    },
+    "delay": 0,
+    "pass": false
+  },
+  {
+    "desc": "Testing with multiple limits",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "45.85.12.8",
+      ":method": "GET",
+      ":path": "/limits/multi",
+      ":authority": "localhost:30081",
+      "h2": "A"
+    },
+    "delay": 0,
+    "pass": false
+  }
+]


### PR DESCRIPTION
Fixes #650. The bug was that when a "limit key" can't be built, the
filter decision would be to let pass instead of checking the other
limits.

This means that, for exemple, if a limit counts on a header, and that
header was not present, then subsequent limits would not be checked.