### PR TITLE
Order security policies by decreasing matcher length

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/config.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config.rs
@@ -199,6 +199,9 @@ impl Config {
             }
         }
 
+        // order by decreasing matcher length, so that more specific rules are matched first
+        securitypolicies.sort_by(|a, b| b.matcher.as_str().len().cmp(&a.matcher.as_str().len()));
+
         let globalfilters = GlobalFilterSection::resolve(logs, rawglobalfilters);
 
         let flows = flow_resolve(logs, rawflows);

--- a/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
@@ -1,5 +1,37 @@
 [
     {
+        "match": "dummydomain.com",
+        "id": "dummydomain",
+        "name": "dummy domain policy",
+        "map": [
+            {
+                "match": "/",
+                "name": "default",
+                "acl_profile": "__default__",
+                "acl_active": false,
+                "content_filter_profile": "__default__",
+                "content_filter_active": false,
+                "limit_ids": []
+            }
+        ]
+    },
+    {
+        "match": "specific.dummydomain.com",
+        "id": "specdummydomain",
+        "name": "more specific dummy domain policy",
+        "map": [
+            {
+                "match": "/",
+                "name": "default",
+                "acl_profile": "__default__",
+                "acl_active": false,
+                "content_filter_profile": "__default__",
+                "content_filter_active": false,
+                "limit_ids": []
+            }
+        ]
+    },
+    {
         "match": "__default__",
         "id": "__default__",
         "name": "default entry",

--- a/curiefense/curieproxy/rust/luatests/raw_requests/test-multidomain.json
+++ b/curiefense/curieproxy/rust/luatests/raw_requests/test-multidomain.json
@@ -1,0 +1,63 @@
+[
+  {
+    "response": {
+      "tags": [
+        "asn:396507",
+        "sante",
+        "ip:23-129-64-253",
+        "contentfilterid:--default--",
+        "contentfiltername:default-contentfilter",
+        "container:1e219d8ed6b4",
+        "all",
+        "securitypolicy:dummy-domain-policy",
+        "securitypolicy-entry:default",
+        "aclid:--default--",
+        "geo:united-states",
+        "bot",
+        "aclname:default-acl"
+      ],
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "md libinjection xss",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.129.64.253",
+      ":path": "\/test\/?a=1&b=%3Cscript%3Edocument.body.innerHTML=",
+      ":method": "GET",
+      ":authority": "dummydomain.com"
+    }
+  },
+  {
+    "response": {
+      "tags": [
+        "securitypolicy:more-specific-dummy-domain-policy",
+        "securitypolicy-entry:default",
+        "ip:23-129-64-253",
+        "sante",
+        "all",
+        "container:1e219d8ed6b4",
+        "geo:united-states",
+        "asn:396507",
+        "contentfilterid:--default--",
+        "contentfiltername:default-contentfilter",
+        "aclid:--default--",
+        "bot",
+        "aclname:default-acl"
+      ],
+      "action": "custom_response",
+      "block_mode": false,
+      "status": 403
+    },
+    "name": "md sqli (header)",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.129.64.253",
+      ":path": "\/test\/",
+      ":method": "GET",
+      ":authority": "specific.dummydomain.com",
+      "malicious": "xp_cmdshell"
+    }
+  }
+]

--- a/curiefense/curieproxy/rust/luatests/test.lua
+++ b/curiefense/curieproxy/rust/luatests/test.lua
@@ -64,6 +64,7 @@ end
 -- test that two lists contain the same tags
 local function compare_tag_list(name, actual, expected)
   local m_actual = {}
+  local good = true
   for _, a in ipairs(actual) do
     if not startswith(a, "container:") then
       m_actual[a] = 1
@@ -71,11 +72,18 @@ local function compare_tag_list(name, actual, expected)
   end
   for _, e in ipairs(expected) do
     if not startswith(e, "container:") and not m_actual[e] then
-      error(name .. " - missing expected tag: " .. e)
+      good = false
+      print(name .. " - missing expected tag: " .. e)
     end
     m_actual[e] = nil
   end
-  local good = true
+  if not good then
+    print("Actual tags:")
+    for _, e in ipairs(actual) do
+      print("  " .. e)
+    end
+    error("^ missing tags in " .. name)
+  end
   for a, _ in pairs(m_actual) do
     print(a)
     good = false


### PR DESCRIPTION
So that more specific rules get selected first.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>