### PR TITLE
curielogger: add authority to output logs

### DIFF
--- a/curiefense/curielogger/pkg/entities/misc.go
+++ b/curiefense/curielogger/pkg/entities/misc.go
@@ -65,6 +65,7 @@ type RequestAttributes struct {
 	URI    string `parquet:"name=uri, type=BYTE_ARRAY, convertedtype=UTF8" json:"uri,omitempty"`
 	Path   string `parquet:"name=path, type=BYTE_ARRAY, convertedtype=UTF8" json:"path,omitempty"`
 	Method string `parquet:"name=method, type=BYTE_ARRAY, convertedtype=UTF8" json:"method,omitempty"`
+	Authority string `parquet:"name=authority, type=BYTE_ARRAY, convertedtype=UTF8" json:"authority,omitempty"`
 }
 
 type Request struct {


### PR DESCRIPTION
Without this, logs do not contain the authority (`Host` header), which is useful for data analysis.
Tested on GKE.

This would fix #619, and is a simpler implementation than PR #620 (no duplication of fields)

Signed-off-by: Xavier <xavier@reblaze.com>