### PR TITLE
Set default values for limit include exclude

### DIFF
--- a/curiefense/images/confserver/bootstrap/confdb-initial-data/master/config/json/limits.json
+++ b/curiefense/images/confserver/bootstrap/confdb-initial-data/master/config/json/limits.json
@@ -12,8 +12,8 @@
                 }
             }
         ],
-        "include": ["blocklist"],
-        "exclude": ["allowlist"],
+        "include": ["all"],
+        "exclude": [],
         "key": [
             {
                 "attrs": "ip"


### PR DESCRIPTION
According to this bug https://github.com/curiefense/curiefense/issues/658 was needed to set default values for include and exclude in initial DB.
```
     "exclude": [],
     "include": ["all"],
```
