### PR TITLE
Performance testing with locust

### DIFF
--- a/deploy/curiefense-helm/example-miniocfg.yaml
+++ b/deploy/curiefense-helm/example-miniocfg.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Secret
+data:
+  miniocfg: "W2RlZmF1bHRdCmFjY2Vzc19rZXkgPSBtaW5pb2FkbWluCnNlY3JldF9rZXkgPSBtaW5pb2FkbWluCg=="
+metadata:
+  labels:
+    app.kubernetes.io/name: miniocfg
+  name: miniocfg
+  namespace: curiefense
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+data:
+  miniocfg: "W2RlZmF1bHRdCmFjY2Vzc19rZXkgPSBtaW5pb2FkbWluCnNlY3JldF9rZXkgPSBtaW5pb2FkbWluCg=="
+metadata:
+  labels:
+    app.kubernetes.io/name: miniocfg
+  name: miniocfg
+  namespace: istio-system
+type: Opaque

--- a/deploy/curiefense-helm/use-minio-curiefense.yaml
+++ b/deploy/curiefense-helm/use-minio-curiefense.yaml
@@ -1,0 +1,7 @@
+---
+# use this file to override default values from ../values.yaml
+# ./deploy.sh -f curiefense/use-minio.yaml
+global:
+  settings:
+    curieconf_manifest_url: 'minio://curiefense-minio-bucket/prod/manifest.json'
+    curiefense_bucket_type: 'minio'

--- a/deploy/curiefense-helm/use-minio-istio.yaml
+++ b/deploy/curiefense-helm/use-minio-istio.yaml
@@ -1,0 +1,8 @@
+---
+# use this file to override default values from ../values.yaml
+# ./deploy.sh -f use-minio.yaml
+global:
+  proxy:
+    curieconf_manifest_url: 'minio://curiefense-minio-bucket/prod/manifest.json'
+    curiefense_bucket_type: 'minio'
+

--- a/deploy/locustfile.py
+++ b/deploy/locustfile.py
@@ -1,0 +1,81 @@
+import json
+from locust import HttpUser, task, between, events
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    parser.add_argument(
+        "--cf-reqsize",
+        type=str,
+        env_var="LOCUST_CF_REQSIZE",
+        default="",
+        help="Request size (kB)",
+    )
+    parser.add_argument(
+        "--cf-testid",
+        type=str,
+        env_var="LOCUST_CF_TESTID",
+        default="default",
+        help="Test identifier",
+    )
+
+
+class Curiefense(HttpUser):
+    wait_time = between(0.1, 0.2)
+
+    def on_start(self):
+        self.client.verify = False
+
+    def gen_payload(self, size_kb: int):
+        if size_kb == 0:
+            return ""
+        else:
+            return json.dumps(
+                [
+                    # 100 bytes after json encoding
+                    {"contents": "testcontent " * 7},
+                ]
+                * (size_kb * 10 - 1)
+                + [
+                    # 100 bytes after json encoding, including surrounding list
+                    {"content": "aa5%3Cimg%20src=1%20onerror=console.log(4)%3E"},
+                    {"padding": "A" * 21},
+                ]
+            )
+
+    @task(1)
+    def curiefense_perf3(self):
+        reqsize = int(self.environment.parsed_options.cf_reqsize)
+        headers = {}
+        if reqsize >= 1:
+            headers = {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+                "Cookie": "inst=APP_4L;BrowserId=AAAAAAAAAAAAAAAAAAAAAA;BrowserId_sec=BBBBBBBBBBBBBBBBBBBBBB; YYY-stream=CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC; force-proxy-stream=DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD; force-stream=EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE; sid=FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; sid_Client=GGGGGGGGGGGGGGGGGGGGGG;clientSrc=1.2.3.4",
+                "Accept-Encoding": "gzip, deflate",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "none",
+                "Sec-Fetch-User": "?1",
+                "Upgrade-Insecure-Requests": "1",
+                "Content-Type": "application/json",
+            }
+            # header size:
+            # len("\n".join([f"{k}: {v}" for k, v in headers.items()])) = 1000
+        payload = self.gen_payload(size_kb=reqsize - 1)
+        with self.client.post(
+            f"/invalid/{self.environment.parsed_options.cf_testid}",
+            data=payload,
+            headers=headers,
+            allow_redirects=False,
+            catch_response=True,
+        ) as response:
+            if response.status_code not in [403, 404, 483]:
+                response.success()
+            else:
+                response.failure(
+                    "Did not get expected code:" + str(response.status_code)
+                )

--- a/deploy/locusttest.sh
+++ b/deploy/locusttest.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+NAME="$1"
+REQSIZEKB="$2"
+NODE_IP=$(kubectl get nodes -o json|jq '.items[0].status.addresses[]|select(.type=="ExternalIP").address'|tr -d '"')
+JAEGER_URL="http://$NODE_IP:30686/jaeger/api/"
+LOCUST_URL="http://$NODE_IP:30400"
+OUTDIR="stats-locust/$NAME"
+mkdir -p "$OUTDIR"
+
+for UC in 10 50 100 200 400 500 600; do
+	# 1 user is about 6 RPS
+	echo -en "\n=== $UC concurrent users, request size $REQSIZEKB kB ===\n"
+	OUTNAME="uc-$UC-$REQSIZEKB"
+	TESTID="$OUTNAME-$NAME"
+	curl "${LOCUST_URL}/swarm" -X POST -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data-raw "user_count=$UC&spawn_rate=1000&host=http%3A%2F%2Fistio-ingressgateway.istio-system%2Fratings&cf_reqsize=$REQSIZEKB&cf_testid=$TESTID"
+	sleep 60
+
+	curl "${JAEGER_URL}traces?limit=1500&lookback=1h&service=istio-ingressgateway&tags=%7B%22http.url%22%3A%22http%3A%2F%2Fistio-ingressgateway.istio-system%2Fratings%2Finvalid%2F${TESTID}%22%7D" --output "$OUTDIR/jaeger-$OUTNAME.json"
+	kubectl top --namespace istio-system pod |grep ingress | awk '{print "{\"cpu\":\"" $2 "\", \"ram\":\"" $3 "\"}"}' > "$OUTDIR/resources-$OUTNAME.json"
+	curl "${LOCUST_URL}/stats/requests" --output "$OUTDIR/locust-$OUTNAME.json"
+	curl "${LOCUST_URL}/stop"
+done
+

--- a/e2e/latency/Curiefense performance report locust.ipynb
+++ b/e2e/latency/Curiefense performance report locust.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Curiefense performance report\n",
+    "## Set measurement folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import glob\n",
+    "import statistics\n",
+    "import pathlib\n",
+    "\n",
+    "import pandas as pd\n",
+    "from collections import defaultdict\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "DEFAULT_RESULTS_DIR = pathlib.Path(\"./stats-locust\")\n",
+    "RESULTS_DIR = pathlib.Path(os.environ.get(\"RESULTS_DIR\", DEFAULT_RESULTS_DIR))\n",
+    "print(f\"Performance measurements will be read from {RESULTS_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sample data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sample jaeger measurement\n",
+    "Two *spans* are present for each query: one for service `istio-ingressgateway`, one for service `ratings.bookinfo`. Related traces have the same `traceID` attribute. The span for `ratings.bookinfo` has a non-empty `references` attribute, and is smaller than the span for `istio-ingressgateway`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "j = json.load((RESULTS_DIR / \"cf-default-config/jaeger-uc-10-0.json\").open())\n",
+    "j"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a pandas dataframe from jaeger, locust & performance outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def folder2pd(folder):\n",
+    "    res = defaultdict(dict)\n",
+    "    for f in folder.glob(\"locust-*.json\"):\n",
+    "        uc = int(f.stem.split(\"-\")[-2])\n",
+    "        reqsize = int(f.stem.split(\"-\")[-1])\n",
+    "        d = {}\n",
+    "        # locust data\n",
+    "        j = json.load(f.open())\n",
+    "        d[\"LocustP50\"] = j[\"current_response_time_percentile_50\"] / 1000\n",
+    "        d[\"LocustP95\"] = j[\"current_response_time_percentile_95\"] / 1000\n",
+    "        d[\"RPS\"] = j[\"total_rps\"]\n",
+    "        d[\"Reqsize\"] = reqsize\n",
+    "        # jaeger data\n",
+    "        j = json.load((folder / f\"jaeger-uc-{uc}-{reqsize}.json\").open())\n",
+    "        trace_data = defaultdict(lambda: [None, None])\n",
+    "        for span in j[\"data\"]:\n",
+    "            for s in span[\"spans\"]:\n",
+    "                trace_id = s[\"traceID\"]\n",
+    "                duration = s[\"duration\"]\n",
+    "                if len(s[\"references\"]) == 0:\n",
+    "                    # istio trace\n",
+    "                    trace_data[trace_id][0] = float(duration)/1e6\n",
+    "                else:\n",
+    "                    # app trace\n",
+    "                    trace_data[trace_id][1] = float(duration)/1e6\n",
+    "        trace_difference = []\n",
+    "        for (i, a) in trace_data.values():\n",
+    "            if \"denyall\" in folder.name or \"contenfilter-and-acl\" in folder.name:\n",
+    "                # single trace: request was blocked\n",
+    "                if i is None:\n",
+    "                    trace_difference.append(a)\n",
+    "                else:\n",
+    "                    trace_difference.append(i)\n",
+    "                continue\n",
+    "            if i is None or a is None:\n",
+    "                continue\n",
+    "            trace_difference.append(i-a)\n",
+    "        try:\n",
+    "            d[\"JIstioTimeAvg\"] = statistics.fmean(trace_difference)\n",
+    "        except statistics.StatisticsError as e:\n",
+    "            #print(f\"Warning: skipping {folder=} {uc=} {reqsize=}\", e)\n",
+    "            if uc == 10 and reqsize == 0:\n",
+    "                print(f\"Warning: skipping {folder=} {uc=} {reqsize=}\", e)\n",
+    "                print(\"TD\", trace_difference)\n",
+    "                print(trace_data)\n",
+    "            continue\n",
+    "        d[\"JIstioTimeP50\"] = statistics.quantiles(trace_difference, n=2)[-1]\n",
+    "        d[\"JIstioTimeP75\"] = statistics.quantiles(trace_difference, n=4)[-1]\n",
+    "        d[\"JIstioTimeP90\"] = statistics.quantiles(trace_difference, n=10)[-1]\n",
+    "        d[\"JIstioTimeP99\"] = statistics.quantiles(trace_difference, n=100)[-1]\n",
+    "        d[\"JIstioTimeMin\"] = min(trace_difference)\n",
+    "        d[\"JIstioTimeMax\"] = max(trace_difference)\n",
+    "        # resources data\n",
+    "        j = json.load((folder / f\"resources-uc-{uc}-{reqsize}.json\").open())\n",
+    "        d[\"CPU_milli\"] = int(j[\"cpu\"][:-1])\n",
+    "        d[\"RAM_Mo\"] = int(j[\"ram\"][:-2])\n",
+    "        res[(uc,reqsize)] = d\n",
+    " \n",
+    "    return pd.DataFrame(res.values())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "folders = RESULTS_DIR.glob(\"*\")\n",
+    "data = {f.name: folder2pd(f) for f in folders}\n",
+    "\n",
+    "data[\"cf-default-config\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Draw QPS vs time percentile\n",
+    "As measured from locust"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def qps_vs(col, args, ylim=None, filterstr=\"\"):\n",
+    "    datalbls, vals = list(zip(*args.items()))\n",
+    "    plotlbls = []\n",
+    "    for idx, m in enumerate(vals):\n",
+    "        for rs in sorted(m.Reqsize.unique()):\n",
+    "            lbl = f\"{datalbls[idx]}-{rs}kB\"\n",
+    "            if filterstr not in lbl:\n",
+    "                # skip this line\n",
+    "                continue\n",
+    "            t = (m[m[\"Reqsize\"] == rs]).sort_values(by=[\"RPS\"])\n",
+    "            p = plt.plot(t[\"RPS\"],t[col])\n",
+    "            plotlbls.append(f\"{datalbls[idx]}-{rs}kB\")\n",
+    "    plt.legend(plotlbls)\n",
+    "    plt.xlabel(\"Actual RPS\")\n",
+    "    plt.ylabel(f\"{col} (s)\")\n",
+    "    if ylim:\n",
+    "        plt.ylim(ylim)\n",
+    "    plt.title(f\"RPS vs {col}\")\n",
+    "\n",
+    "def big_plot(*args, **kargs):\n",
+    "    fig = plt.figure(figsize=(20,20), dpi=72)\n",
+    "    qps_vs(*args, **kargs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qps_vs(\"LocustP50\", data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "big_plot(\"LocustP95\", data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_all(args, lines=[[\"LocustP50\",\"LocustP95\"]], ylim=None, filterstr=\"\"):\n",
+    "    h = len(lines)\n",
+    "    w = max([len(cols) for cols in lines])\n",
+    "    fig = plt.figure(figsize=(w*6, h*2), dpi= 100)\n",
+    "    fig.set_facecolor(\"white\")\n",
+    "    plt.subplots_adjust(top=2)\n",
+    "    \n",
+    "    for i, cols in enumerate(lines):\n",
+    "        for j, col in enumerate(cols):\n",
+    "            fig.add_subplot(h, w, 1+(i*w)+j)\n",
+    "            qps_vs(col, args, filterstr=filterstr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_all(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Draw QPS vs latency introduced by istio\n",
+    "As measured from jaeger\n",
+    "### Influence of the configuration, for a 0kB payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "plot_all(data, lines=[[\"LocustP50\",\"LocustP95\"],[\"JIstioTimeP50\", \"JIstioTimeP90\", \"JIstioTimeP99\"],[\"CPU_milli\",\"RAM_Mo\"]], filterstr=\"-0kB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Effect of the payload size, for the default configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_all(data, lines=[[\"LocustP50\",\"LocustP95\"],[\"JIstioTimeP50\", \"JIstioTimeP90\", \"JIstioTimeP99\"],[\"CPU_milli\",\"RAM_Mo\"]], filterstr=\"default-config\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_all(data, lines=[[\"LocustP50\",\"LocustP95\"],[\"JIstioTimeP50\", \"JIstioTimeP90\", \"JIstioTimeP99\"],[\"CPU_milli\",\"RAM_Mo\"]], filterstr=\"deny\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/e2e/latency/locust-service.yml
+++ b/e2e/latency/locust-service.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: locust
+  name: locust
+  namespace: locust
+spec:
+  ports:
+  - name: "locust"
+    port: 8089
+    targetPort: 8089
+    nodePort: 30400
+  selector:
+    app.kubernetes.io/name: locust
+    component: master
+  type: NodePort
+  externalTrafficPolicy: "Cluster"

--- a/e2e/set_config.py
+++ b/e2e/set_config.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Used for e2e tests to set configuration
+
+import test_e2e
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-u", "--base-url", help="Base url for API", default="http://localhost:5000/api/v2/"
+)
+parser.add_argument(
+    "CONFIGNAME", choices=["denyall", "defaultconfig", "contentfilter-and-acl"]
+)
+args = parser.parse_args()
+
+cli = test_e2e.CliHelper(args.base_url)
+acl = test_e2e.ACLHelper(cli)
+if args.CONFIGNAME == "denyall":
+    acl.reset_and_set_acl({"force_deny": "all"})
+elif args.CONFIGNAME == "defaultconfig":
+    cli.revert_and_enable(False, False)
+    cli.publish_and_apply()
+elif args.CONFIGNAME == "contentfilter-and-acl":
+    cli.revert_and_enable(True, True)
+    cli.publish_and_apply()


### PR DESCRIPTION
Locust runs several "workers" that issues queries, which allows us to
reach higher request per second (RPS) than with fortio. Queries sizes are
now a parameter; the test script uses this new feature to collect and
generate report.

When testing with locust, we deploy 3 nodes:
* 1 node for locust master & workers that generate traffic
* 1 node for istio's ingressgateway
* 1 node for all other components: confserver, target services

This PR uses minio to store published configurations instead of S3,
which means AWS credentials are not needed anymore.

Signed-off-by: Xavier <xavier@reblaze.com>