### PR TITLE
Move the `eu` field from `country` to its parent container, `geo`

### DIFF
--- a/curiefense/curielogger/pkg/entities/misc.go
+++ b/curiefense/curielogger/pkg/entities/misc.go
@@ -78,6 +78,7 @@ type Request struct {
 	Arguments    map[string]string `parquet:"name=arguments, type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, keyconvertedtype=UTF8, valuetype=BYTE_ARRAY, convertedtype=UTF8" json:"arguments"`
 	Geo          Geo               `parquet:"name=geo, type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, keyconvertedtype=UTF8, valuetype=BYTE_ARRAY, convertedtype=UTF8" json:"geo"`
 	Attributes   RequestAttributes `parquet:"name=attributes, type=MAP" json:"attributes"`
+	Eu           bool              `parquet:"name=eu, type=BOOLEAN" json:"eu"`
 }
 
 type Geo struct {

--- a/curiefense/curieproxy/rust/curiefense/src/utils.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/utils.rs
@@ -132,10 +132,10 @@ impl GeoIp {
             } }),
         );
 
+        out.insert("eu", json!(self.in_eu));
         out.insert(
             "country",
             json!({
-                "eu": self.in_eu,
                 "name": self.country_name,
                 "iso": self.country_iso
             }),


### PR DESCRIPTION
Shoud fix #663 

Signed-off-by: Simon Marechal <bartavelle@gmail.com>