### PR TITLE
docker-compose: fix ports for nginx deployment

### DIFF
--- a/deploy/compose/docker-compose-nginx.yaml
+++ b/deploy/compose/docker-compose-nginx.yaml
@@ -17,8 +17,8 @@ services:
         aliases:
           - curieproxy
     ports:
-      - "30081:80"
-      - "30444:443"
+      - "30082:30082"
+      - "30083:30083"
       - "8001:8001"
     secrets:
       - curieproxysslcrt


### PR DESCRIPTION
nginx listens on ports :30082 and :30083 ([ref](https://github.com/curiefense/curiefense/blob/main/curiefense/images/curieproxy-nginx/conf.d/default.conf#L15)). This PR fixes the docker-compose file for nginx deployments to listen on these ports.