### PR TITLE
Make names of folders that store configs more specific

### DIFF
--- a/curiefense/curieconf/server/app/main.py
+++ b/curiefense/curieconf/server/app/main.py
@@ -1,4 +1,4 @@
 from curieconf.confserver import app
 from curieconf.confserver.backend import Backends
 
-app.backend = Backends.get_backend(app, "git:///config/confdb")
+app.backend = Backends.get_backend(app, "git:///cf-persistent-config/confdb")

--- a/curiefense/curieproxy/rust/Makefile
+++ b/curiefense/curieproxy/rust/Makefile
@@ -43,10 +43,10 @@ test-nodeps:
 						 -v `pwd`/../lua/shared-objects/luahs.so:/usr/local/lib/lua/5.1/luahs.so \
 						 -v `pwd`/../lua/shared-objects/libinjection.so:/usr/local/lib/lua/5.1/libinjection.so \
 						 -v `pwd`/../lua/shared-objects/grasshopper.so:/usr/local/lib/lua/5.1/grasshopper.so \
-						 -v `pwd`/../../images/confserver/bootstrap/confdb-initial-data/master/config:/config/current/config \
+						 -v `pwd`/../../images/confserver/bootstrap/confdb-initial-data/master/config:/cf-config/current/config \
 						 -v `pwd`/luatests/test.lua:/home/builder/test.lua \
 						 -v `pwd`/luatests/run.sh:/home/builder/run.sh \
-						 -v `pwd`/luatests/config/json:/config/current/config/json \
+						 -v `pwd`/luatests/config/json:/cf-config/current/config/json \
 						 -v `pwd`/luatests:/home/builder/luatests \
 						 --rm \
 						 -w /home/builder -t curiefense/rustbuild:latest \

--- a/curiefense/curieproxy/rust/curiefense-lua/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense-lua/src/lib.rs
@@ -40,7 +40,7 @@ fn lua_inspect_content_filter(
     let (meta, headers, lua_body, str_ip, content_filter_id) = args;
 
     let res = match lua_body {
-        None => inspect_content_filter("/config/current/config", meta, headers, None, str_ip, content_filter_id),
+        None => inspect_content_filter("/cf-config/current/config", meta, headers, None, str_ip, content_filter_id),
         Some(body) => inspect_content_filter(
             "/config/current/config",
             meta,
@@ -114,9 +114,9 @@ fn lua_inspect_request(
 
     // TODO: solve the lifetime issue for the &[u8] to reduce duplication
     let res = match lua_body {
-        None => inspect_request("/config/current/config", meta, headers, None, str_ip, grasshopper),
+        None => inspect_request("/cf-config/current/config", meta, headers, None, str_ip, grasshopper),
         Some(body) => inspect_request(
-            "/config/current/config",
+            "/cf-config/current/config",
             meta,
             headers,
             Some(body.as_bytes()),
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn config_load() {
         let mut logs = Logs::default();
-        let cfg = with_config("../../config", &mut logs, |_, c| c.clone());
+        let cfg = with_config("../../cf-config", &mut logs, |_, c| c.clone());
         if cfg.is_some() {
             match logs.logs.len() {
                 1 => {
@@ -192,7 +192,7 @@ mod tests {
                     assert!(logs.logs[0]
                         .message
                         .to_string()
-                        .contains("../../config: No such file or directory"))
+                        .contains("../../cf-config: No such file or directory"))
                 }
                 n => {
                     for r in logs.logs.iter() {

--- a/curiefense/curieproxy/rust/curiefense/src/config.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config.rs
@@ -60,7 +60,7 @@ pub fn with_config_default_path<R, F>(logs: &mut Logs, f: F) -> Option<R>
 where
     F: FnOnce(&mut Logs, &Config) -> R,
 {
-    with_config("/config/current/config", logs, f)
+    with_config("/cf-config/current/config", logs, f)
 }
 
 #[derive(Debug, Clone)]

--- a/curiefense/curieproxy/rust/curiefense/src/maxmind.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/maxmind.rs
@@ -10,12 +10,12 @@ use std::ops::Deref;
 lazy_static! {
     // as they are lazy, these loads will not be triggered in test mode
     static ref ASN: Result<Reader<Vec<u8>>, maxminddb::MaxMindDBError> =
-        Reader::open_readfile("/config/current/config/maxmind/GeoLite2-ASN.mmdb");
+        Reader::open_readfile("/cf-config/current/config/maxmind/GeoLite2-ASN.mmdb");
     static ref COUNTRY: Result<Reader<Vec<u8>>, maxminddb::MaxMindDBError> =
-        Reader::open_readfile("/config/current/config/maxmind/GeoLite2-Country.mmdb");
+        Reader::open_readfile("/cf-config/current/config/maxmind/GeoLite2-Country.mmdb");
     static ref CITY: Result<Reader<Vec<u8>>, maxminddb::MaxMindDBError> =
-        Reader::open_readfile("/config/current/config/maxmind/GeoIP2-City.mmdb").or_else(|_|
-        Reader::open_readfile("/config/current/config/maxmind/GeoLite2-City.mmdb"));
+        Reader::open_readfile("/cf-config/current/config/maxmind/GeoIP2-City.mmdb").or_else(|_|
+        Reader::open_readfile("/cf-config/current/config/maxmind/GeoLite2-City.mmdb"));
 }
 
 /// Retrieves the english name of the country associated with this IP

--- a/curiefense/images/confserver/bootstrap/bootstrap_config.sh
+++ b/curiefense/images/confserver/bootstrap/bootstrap_config.sh
@@ -3,8 +3,8 @@
 set -e
 
 # to be run in an initContainer
-# Will deploy specified configuration as a bootstrap config, if there is no config in /config/confdb
-TARGETDIR="/config/confdb"
+# Will deploy specified configuration as a bootstrap config, if there is no config in /cf-persistent-config/confdb
+TARGETDIR="/cf-persistent-config/confdb"
 
 if [ -e "$TARGETDIR" ]; then
 	echo "Config already present in $TARGETDIR, exiting"

--- a/curiefense/images/curiefense-nginx-ingress/Dockerfile
+++ b/curiefense/images/curiefense-nginx-ingress/Dockerfile
@@ -58,13 +58,13 @@ RUN sed -i "/^http {/a log_format curiefenselog escape=none '\$request_map';" /n
 COPY curieproxy/lua/shared-objects/*.so /usr/local/lib/lua/5.1/
 COPY --from=rustbin /root/curiefense.so /usr/local/lib/lua/5.1/
 
-COPY curieproxy/config /bootstrap-config/config
+COPY curieproxy/config /cf-bootstrap-config/config
 COPY curieproxy/lua /lua
 RUN rm -f /lua/session.lua && ln -s /lua/session_nginx.lua /lua/session.lua
 
 ENTRYPOINT ["/curiefense-nginx.sh"]
 
-RUN mkdir /config && chmod a+rwxt /config
+RUN mkdir /cf-config && chmod a+rwxt /cf-config
 RUN mkfifo /nginx-accesslogs
 
 COPY curiefense-nginx.sh /curiefense-nginx.sh

--- a/curiefense/images/curiefense-rustbuild/Dockerfile
+++ b/curiefense/images/curiefense-rustbuild/Dockerfile
@@ -24,9 +24,9 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 
 RUN cp /root/curiefense.so /usr/local/lib/lua/5.1/curiefense.so
 COPY curieproxy/lua/shared-objects/grasshopper.so /usr/local/lib/lua/5.1/grasshopper.so
-RUN mkdir -p /config/current
-COPY confdb-initial-data/master/config /config/current/config
-COPY curieproxy/rust/luatests/config/json /config/current/config/json
+RUN mkdir -p /cf-config/current
+COPY confdb-initial-data/master/config /cf-config/current/config
+COPY curieproxy/rust/luatests/config/json /cf-config/current/config/json
 
 RUN useradd -m -s /bin/bash builder
 USER builder

--- a/curiefense/images/curieproxy-envoy/init/start_curiefense.sh
+++ b/curiefense/images/curieproxy-envoy/init/start_curiefense.sh
@@ -1,13 +1,13 @@
 #! /bin/bash
 
-if [ ! -e /config/bootstrap ]
+if [ ! -e /cf-config/bootstrap ]
 then
-	cp -va /bootstrap-config /config/bootstrap
+	cp -va /bootstrap-config /cf-config/bootstrap
 fi
 
-if [ ! -e /config/current ]
+if [ ! -e /cf-config/current ]
 then
-	ln -s bootstrap /config/current
+	ln -s bootstrap /cf-config/current
 fi
 
 TADDR="${TARGET_ADDRESS:-echo}"

--- a/curiefense/images/curieproxy-istio/init/start_curiefense_pilot.sh
+++ b/curiefense/images/curieproxy-istio/init/start_curiefense_pilot.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -e
 
-if [ ! -e /config/bootstrap ]
+if [ ! -e /cf-config/bootstrap ]
 then
-	cp -va /bootstrap-config /config/bootstrap
+	cp -va /bootstrap-config /cf-config/bootstrap
 fi
 
-if [ ! -e /config/current ]
+if [ ! -e /cf-config/current ]
 then
-	ln -s bootstrap /config/current
+	ln -s bootstrap /cf-config/current
 fi
 
 if [ -n "$BOOTSTRAP_ONLY" ]; then

--- a/curiefense/images/curiesync/init/pull.sh
+++ b/curiefense/images/curiesync/init/pull.sh
@@ -19,21 +19,21 @@ fi
 
 if [ "$RUN_MODE" = "SYNC_ONCE" ]; then
     info "Synchronizing once"
-    curieconfctl sync pull "${CURIE_BUCKET_LINK}" /config
+    curieconfctl sync pull "${CURIE_BUCKET_LINK}" /cf-config
     exit 0
 fi
 
 if [ "$RUN_MODE" = "COPY_BOOTSTRAP" ]; then
     info "Copying bootstrap config"
-    if [ ! -e /config/bootstrap ]
+    if [ ! -e /cf-config/bootstrap ]
     then
-        mkdir -p /config
-        cp -va /bootstrap-config /config/bootstrap
+        mkdir -p /cf-config
+        cp -va /bootstrap-config /cf-config/bootstrap
     fi
 
-    if [ ! -e /config/current ]
+    if [ ! -e /cf-config/current ]
     then
-        ln -s bootstrap /config/current
+        ln -s bootstrap /cf-config/current
     fi
     exit 0
 fi
@@ -44,7 +44,7 @@ if [ "$RUN_MODE" = "PERIODIC_SYNC" ] || [ -z "$RUN_MODE" ]; then
     while :;
     do
         info "Pulling ${CURIE_BUCKET_LINK}"
-        curieconfctl sync pull "${CURIE_BUCKET_LINK}" /config
+        curieconfctl sync pull "${CURIE_BUCKET_LINK}" /cf-config
         info "Sleeping"
         sleep $PERIOD
     done

--- a/deploy/compose/docker-compose-nginx.yaml
+++ b/deploy/compose/docker-compose-nginx.yaml
@@ -6,7 +6,7 @@ services:
     image: "curiefense/curieproxy-nginx:${DOCKER_TAG}"
     restart: always
     volumes:
-      - curieproxy_config:/config
+      - curieproxy_config:/cf-config
     environment:
       - ENVOY_UID
       - TARGET_ADDRESS=echo # currently hard-coded
@@ -30,7 +30,7 @@ services:
     image: "curiefense/confserver:${DOCKER_TAG}"
     restart: always
     volumes:
-      - persistent_confdb:/config
+      - persistent_confdb:/cf-persistent-config
       - local_bucket:/bucket
     tty: true
     environment:
@@ -54,7 +54,7 @@ services:
     restart: always
     volumes:
       - local_bucket:/bucket
-      - curieproxy_config:/config
+      - curieproxy_config:/cf-config
     tty: true
     environment:
       - CURIE_BUCKET_LINK

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     image: "curiefense/curieproxy-envoy:${DOCKER_TAG}"
     restart: always
     volumes:
-      - curieproxy_config:/config
+      - curieproxy_config:/cf-config
     environment:
       - ENVOY_UID
       - TARGET_ADDRESS=echo
@@ -31,7 +31,7 @@ services:
     image: "curiefense/confserver:${DOCKER_TAG}"
     restart: always
     volumes:
-      - persistent_confdb:/config
+      - persistent_confdb:/cf-persistent-config
       - local_bucket:/bucket
     tty: true
     environment:
@@ -55,7 +55,7 @@ services:
     restart: always
     volumes:
       - local_bucket:/bucket
-      - curieproxy_config:/config
+      - curieproxy_config:/cf-config
     tty: true
     environment:
       - CURIE_BUCKET_LINK

--- a/e2e/logs-smoke-test/patterns/compose-confserver-patterns.txt
+++ b/e2e/logs-smoke-test/patterns/compose-confserver-patterns.txt
@@ -1,4 +1,4 @@
-^Config already present in /config/confdb, exiting
+^Config already present in /cf-config/confdb, exiting
 ^Configuration of bucket \S+ successful
 ^Trying to request export to bucket \S+
 ^Export to bucket \S+ successful
@@ -67,10 +67,10 @@
 ^spawned uWSGI worker \S+ \(pid: \S+ cores: \S+
 ^running "unix_signal:15 gracefully_kill_them_all" \(master-start\)...
 ^\[pid: \S+|app: \S+|req: \S+/\S+\] \S+ \(\) \{\S+ vars in \S+ bytes\} [[^]]+] (GET|PUT|DELETE|POST) /api/v2/\S* => generated \S+ bytes in \S+ msecs (HTTP/1.[01] 200)
-^Config directory /config/confdb is empty
+^Config directory /cf-config/confdb is empty
 ^Cloning configuration from /bootstrap/confdb.bundle
-^Cloning into bare repository '/config/confdb'...
-^Initialized empty Git repository in /config/confdb/
+^Cloning into bare repository '/cf-config/confdb'...
+^Initialized empty Git repository in /cf-config/confdb/
 ^Cloning into 'bootstrap-repo'...
 ^warning: You appear to have cloned an empty repository.
 ^done.
@@ -88,7 +88,7 @@
 ^  \(use "git branch --unset-upstream" to fixup\)
 ^\[master \S+\] Create config \[master\]
 ^ rewrite config/.*.json \(\S+%\)
-^To /config/confdb
+^To /cf-config/confdb
 ^ \* \[new branch\]      \S+ -> \S+
 ^os: Linux-.*
 ^\S+-\S+-\S+ \S+:\S+:\S+,\S+ INFO

--- a/e2e/logs-smoke-test/patterns/compose-curieproxy-patterns.txt
+++ b/e2e/logs-smoke-test/patterns/compose-curieproxy-patterns.txt
@@ -3,13 +3,13 @@
 ^Run mode is \[SYNC_ONCE\]
 ^Run mode is \[PERIODIC_SYNC\]
 ^Synchronizing once
-^Creating configuration \[/config/configs/\S+\]
+^Creating configuration \[/cf-config/configs/\S+\]
 ^Pulling new version of \[config/\S+\]
 ^\s*\S+: \S+$
 ^Pulling \S+\.json$
 ^Synchronizing conf every 10 seconds
 ^Sleeping
-^'/bootstrap-config\S*' -> '/config/\S+'
+^'/bootstrap-config\S*' -> '/cf-config/\S+'
 ^\S+T\S+Z	info	
 ^\s*$
 ^\s*\S+:$

--- a/e2e/logs-smoke-test/patterns/compose-curiesync-patterns.txt
+++ b/e2e/logs-smoke-test/patterns/compose-curiesync-patterns.txt
@@ -3,13 +3,13 @@
 ^Run mode is \[SYNC_ONCE\]
 ^Run mode is \[PERIODIC_SYNC\]
 ^Synchronizing once
-^Creating configuration \[/config/configs/\S+\]
+^Creating configuration \[/cf-config/configs/\S+\]
 ^Pulling new version of \[config/\S+\]
 ^\s*\S+: \S+$
 ^Pulling \S+\.json$
 ^Synchronizing conf every 10 seconds
 ^Sleeping
-^'/bootstrap-config\S*' -> '/config/\S+'
+^'/bootstrap-config\S*' -> '/cf-config/\S+'
 ^\S+T\S+Z	info	
 ^\s*$
 ^\s*\S+:$

--- a/e2e/logs-smoke-test/patterns/curiefense-confserver-patterns.txt
+++ b/e2e/logs-smoke-test/patterns/curiefense-confserver-patterns.txt
@@ -1,4 +1,4 @@
-^Config already present in /config/confdb, exiting
+^Config already present in /cf-config/confdb, exiting
 ^Configuration of bucket \S+ successful
 ^Trying to request export to bucket \S+
 ^Export to bucket \S+ successful
@@ -67,10 +67,10 @@
 ^spawned uWSGI worker \S+ \(pid: \S+ cores: \S+
 ^running "unix_signal:15 gracefully_kill_them_all" \(master-start\)...
 ^\[pid: \S+|app: \S+|req: \S+/\S+\] \S+ \(\) \{\S+ vars in \S+ bytes\} [[^]]+] (GET|PUT|DELETE|POST) /api/v2/\S* => generated \S+ bytes in \S+ msecs (HTTP/1.[01] 200)
-^Config directory /config/confdb is empty
+^Config directory /cf-config/confdb is empty
 ^Cloning configuration from /bootstrap/confdb.bundle
-^Cloning into bare repository '/config/confdb'...
-^Initialized empty Git repository in /config/confdb/
+^Cloning into bare repository '/cf-config/confdb'...
+^Initialized empty Git repository in /cf-config/confdb/
 ^Cloning into 'bootstrap-repo'...
 ^warning: You appear to have cloned an empty repository.
 ^done.
@@ -88,7 +88,7 @@
 ^  \(use "git branch --unset-upstream" to fixup\)
 ^\[master \S+\] Create config \[master\]
 ^ rewrite config/.*.json \(\S+%\)
-^To /config/confdb
+^To /cf-config/confdb
 ^ \* \[new branch\]      \S+ -> \S+
 ^os: Linux-.*
 ^\S+-\S+-\S+ \S+:\S+:\S+,\S+ INFO

--- a/e2e/logs-smoke-test/patterns/istio-system-istio-ingressgateway-patterns.txt
+++ b/e2e/logs-smoke-test/patterns/istio-system-istio-ingressgateway-patterns.txt
@@ -3,13 +3,13 @@
 ^Run mode is \[SYNC_ONCE\]
 ^Run mode is \[PERIODIC_SYNC\]
 ^Synchronizing once
-^Creating configuration \[/config/configs/\S+\]
+^Creating configuration \[/cf-config/configs/\S+\]
 ^Pulling new version of \[config/\S+\]
 ^\s*\S+: \S+$
 ^Pulling \S+\.json$
 ^Synchronizing conf every 10 seconds
 ^Sleeping
-^'/bootstrap-config\S*' -> '/config/\S+'
+^'/bootstrap-config\S*' -> '/cf-config/\S+'
 ^\S+T\S+Z	info	
 ^\s*$
 ^\s*\S+:$


### PR DESCRIPTION
Two types of configs are currently stored in a folder called /config:
1. in confserver pods, to store the persistent git repo that contains
   confserver's data
2. in curieproxy pods, to store generated configurations (json and
   maxmind files), where they are updated by curieproxy and read by the
   envoy rust module

This commit aims at fixing two issues:
* the use of the "config" name, which is too common. Curiefense users
  have shared deployment customizations where they were already using
  /config to store other sorts of configurations, which conflicted with
  curiefense's use
* the use of the same folder name to store very different things, which
  can be confusing

To achieve this, this commits changes folder names:
* persistent data for confserver will now be stored in
  /cf-persistent-config
* generated configs for the envoy rust module will be in /cf-config