### PR TITLE
Action priority

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/lib.rs
@@ -136,6 +136,7 @@ pub fn inspect_generic_request_map<GH: Grasshopper>(
     logs.debug("challenge phase2 ignored");
 
     if let SimpleDecision::Action(action, reason) = globalfilter_dec {
+        logs.debug(format!("Global filter decision {:?}", reason));
         let decision = action.to_decision(is_human, &mgh, &reqinfo.headers, reason);
         if decision.is_final() {
             return (decision, tags);

--- a/curiefense/curieproxy/rust/luatests/config/json/flow-control.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/flow-control.json
@@ -146,7 +146,7 @@
             }
         },
         "timeframe": 4,
-        "id": "d03dabe4b9ca"
+        "id": "d03dabe4b9cx"
     },
     {
         "exclude": [],
@@ -229,5 +229,126 @@
         },
         "timeframe": 4,
         "id": "flowchallenge"
+    },
+    {
+        "exclude": [],
+        "include": [
+            "all"
+        ],
+        "name": "Flow Control (action collision 1)",
+        "key": [
+            {
+                "attrs": "ip"
+            }
+        ],
+        "sequence": [
+            {
+                "method": "GET",
+                "uri": "/step1",
+                "cookies": {},
+                "headers": {
+                    "host": "www.collision.com"
+                },
+                "args": {}
+            },
+            {
+                "method": "GET",
+                "uri": "/step2",
+                "cookies": {},
+                "headers": {
+                    "host": "www.collision.com"
+                },
+                "args": {}
+            }
+        ],
+        "active": true,
+        "description": "abc",
+        "action": {
+            "type": "monitor"
+        },
+        "timeframe": 4,
+        "id": "col1"
+    },
+    {
+        "exclude": [],
+        "include": [
+            "all"
+        ],
+        "name": "Flow Control (action collision 2)",
+        "key": [
+            {
+                "attrs": "ip"
+            }
+        ],
+        "sequence": [
+            {
+                "method": "GET",
+                "uri": "/step1",
+                "cookies": {},
+                "headers": {
+                    "host": "www.collision.com"
+                },
+                "args": {}
+            },
+            {
+                "method": "GET",
+                "uri": "/step2",
+                "cookies": {},
+                "headers": {
+                    "host": "www.collision.com"
+                },
+                "args": {}
+            }
+        ],
+        "active": true,
+        "description": "abc",
+        "action": {
+            "type": "challenge"
+        },
+        "timeframe": 4,
+        "id": "col2"
+    },
+    {
+        "exclude": [],
+        "include": [
+            "all"
+        ],
+        "name": "Flow Control (action collision 3)",
+        "key": [
+            {
+                "attrs": "ip"
+            }
+        ],
+        "sequence": [
+            {
+                "method": "GET",
+                "uri": "/step1",
+                "cookies": {},
+                "headers": {
+                    "host": "www.collision.com"
+                },
+                "args": {}
+            },
+            {
+                "method": "GET",
+                "uri": "/step2",
+                "cookies": {},
+                "headers": {
+                    "host": "www.collision.com"
+                },
+                "args": {}
+            }
+        ],
+        "active": true,
+        "description": "abc",
+        "action": {
+            "params": {
+                "location": "http://www.redir.com",
+                "status": "333"
+            },
+            "type": "redirect"
+        },
+        "timeframe": 4,
+        "id": "col3"
     }
 ]

--- a/curiefense/curieproxy/rust/luatests/flows/banning.json
+++ b/curiefense/curieproxy/rust/luatests/flows/banning.json
@@ -17,7 +17,7 @@
       ":authority": "www.example.com"
     },
     "delay": 0,
-    "pass": true
+    "pass": false
   },
   {
     "headers": {
@@ -27,6 +27,6 @@
       ":authority": "www.example.com"
     },
     "delay": 0,
-    "pass": true
+    "pass": false
   }
 ]

--- a/curiefense/curieproxy/rust/luatests/raw_requests/collision.json
+++ b/curiefense/curieproxy/rust/luatests/raw_requests/collision.json
@@ -1,0 +1,36 @@
+[
+  {
+    "headers": {
+      ":authority": "www.collision.com",
+      ":method": "GET",
+      ":path": "/step2",
+      "user-agent": "dummy",
+      "host": "www.collision.com",
+      "x-forwarded-for": "2.3.4.5"
+    },
+    "name": "test multi flow actions",
+    "response": {
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 247,
+      "tags": [
+        "all",
+        "ip:2-3-4-5",
+        "sante",
+        "securitypolicy-entry:default",
+        "contentfiltername:default-contentfilter",
+        "securitypolicy:default-entry",
+        "aclname:default-acl",
+        "aclid:--default--",
+        "contentfilterid:--default--",
+        "bot",
+        "geo:france",
+        "asn:3215",
+        "challenge-phase01",
+        "flow-control--action-collision-3-",
+        "flow-control--action-collision-1-",
+        "flow-control--action-collision-2-"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Flow control : multiple actions priority

Previously, when several flow control rules would attempt to block a
request, the selected action was undefined. It is now guaranteed that
the action with the highest priority is selected, where the priority is
computed this way:

```rust
    Ban(sub, _) => 10 + sub.atype.priority(),
    Default => 8,
    Challenge => 6,
    Redirect(_) => 4,
    Response(_) => 3,
    RequestHeader(_) => 2,
    Monitor => 1,
```

If several actions have the maximum priority, one of them is selected in
an undefined manner.
