### PR TITLE
Fix logging when human & bot are ACL blocked

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/lib.rs
@@ -179,6 +179,21 @@ pub fn inspect_generic_request_map<GH: Grasshopper>(
                 Some((0, dec.tags))
             }
         }
+        // bot blocked, human blocked
+        // effect would be identical to the following case except for logging purpose
+        AclResult::Match(BotHuman {
+            bot: Some(AclDecision {
+                allowed: false,
+                tags: dtags,
+            }),
+            human: Some(AclDecision {
+                allowed: false,
+                tags: _,
+            }),
+        }) => {
+            logs.debug("ACL human block detected");
+            Some((5, dtags))
+        }
         // human blocked, always block, even if it is a bot
         AclResult::Match(BotHuman {
             bot: _,


### PR DESCRIPTION
The blocking logic was sound, but the logging would not display the
proper block reason when bot + human were set to block.

This patch adds a special case.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>