### PR TITLE
Remove rule 100145

### DIFF
--- a/curiefense/images/confserver/bootstrap/confdb-initial-data/master/config/json/contentfilter-rules.json
+++ b/curiefense/images/confserver/bootstrap/confdb-initial-data/master/config/json/contentfilter-rules.json
@@ -1430,16 +1430,6 @@
     "subcategory": "generic"
   },
   {
-    "id": "100145",
-    "name": "100145",
-    "msg": "system resource",
-    "operand": "rfi?..",
-    "severity": 5,
-    "certainity": 5,
-    "category": "generic",
-    "subcategory": "generic"
-  },
-  {
     "id": "100146",
     "name": "100146",
     "msg": "system resource",


### PR DESCRIPTION
This rule (`rfi?..`) has way too many false positives.

Fixes #718 

Signed-off-by: Simon Marechal <bartavelle@gmail.com>