### PR TITLE
Add the capacity to select by tags

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/config/utils.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/utils.rs
@@ -14,6 +14,7 @@ pub enum RequestSelector {
     Header(String),
     Company,
     Authority,
+    Tags,
 }
 
 #[derive(Debug, Clone)]
@@ -42,6 +43,7 @@ pub fn decode_attribute(s: &str) -> Option<RequestSelector> {
         "asn" => Some(RequestSelector::Asn),
         "company" => Some(RequestSelector::Company),
         "authority" => Some(RequestSelector::Authority),
+        "tags" => Some(RequestSelector::Tags),
         _ => None,
     }
 }

--- a/curiefense/curieproxy/rust/curiefense/src/interface.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface.rs
@@ -136,6 +136,12 @@ impl Tags {
     pub fn as_hash_ref(&self) -> &HashSet<String> {
         &self.0
     }
+
+    pub fn selector(&self) -> String {
+        let mut tvec: Vec<&str> = self.0.iter().map(|s| s.as_ref()).collect();
+        tvec.sort_unstable();
+        tvec.join("*")
+    }
 }
 
 // an action, as formatted for outside consumption
@@ -470,4 +476,21 @@ pub fn challenge_phase02<GH: Grasshopper>(gh: &GH, uri: &str, headers: &RequestF
         content: "{}".to_string(),
         extra_tags: Some(["challenge_phase02"].iter().map(|s| s.to_string()).collect()),
     }))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn tag_selector() {
+        let tags = Tags::from_slice(&["ccc".to_string(), "bbb".to_string(), "aaa".to_string()]);
+        assert_eq!(tags.selector(), "aaa*bbb*ccc");
+    }
+
+    #[test]
+    fn tag_selector_r() {
+        let tags = Tags::from_slice(&["aaa".to_string(), "ccc".to_string(), "bbb".to_string()]);
+        assert_eq!(tags.selector(), "aaa*bbb*ccc");
+    }
 }


### PR DESCRIPTION
Tags are sorted and aggregated in order to create a string.

This can be used as counting for rate limiting, with the effects that
requests with identical tags are lumped together.

However, this is expected to be flaky as tags are altered during the
rate limiting operation ...

Signed-off-by: Simon Marechal <bartavelle@gmail.com>