### PR TITLE
Argument masking (standalone)

### DIFF
--- a/curiefense/curieproxy/rust/curiefense-lua/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense-lua/src/lib.rs
@@ -149,13 +149,14 @@ fn inspect_request<GH: Grasshopper>(
 
     let reqinfo = map_request(&mut logs, ip, headers, rmeta, mbody)?;
 
-    let (dec, tags) = inspect_generic_request_map(configpath, grasshopper, &reqinfo, Tags::default(), &mut logs);
+    let (dec, tags, masked_rinfo) = inspect_generic_request_map(configpath, grasshopper, reqinfo, Tags::default(), &mut logs);
+
     Ok(InspectionResult {
         decision: dec,
         tags: Some(tags),
         logs,
         err: None,
-        rinfo: Some(reqinfo),
+        rinfo: Some(masked_rinfo),
     })
 }
 

--- a/curiefense/curieproxy/rust/curiefense/src/config/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/contentfilter.rs
@@ -69,6 +69,7 @@ pub struct ContentFilterSection {
 pub struct ContentFilterEntryMatch {
     pub reg: Option<Regex>,
     pub restrict: bool,
+    pub mask: bool,
     pub exclusions: HashSet<String>,
 }
 
@@ -163,6 +164,7 @@ fn mk_entry_match(
         em.key,
         ContentFilterEntryMatch {
             restrict: em.restrict,
+            mask: em.mask.unwrap_or(false),
             exclusions: em
                 .exclusions
                 .unwrap_or_default()

--- a/curiefense/curieproxy/rust/curiefense/src/config/raw.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/raw.rs
@@ -275,6 +275,7 @@ pub struct RawContentFilterEntryMatch {
     pub key: String,
     pub reg: Option<String>,
     pub restrict: bool,
+    pub mask: Option<bool>,
     pub exclusions: Option<HashMap<String, String>>,
 }
 

--- a/curiefense/curieproxy/rust/curiefense/src/requestfields.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/requestfields.rs
@@ -56,6 +56,15 @@ impl RequestField {
     pub fn iter(&self) -> hash_map::Iter<'_, String, String> {
         self.0.iter()
     }
+
+    pub fn iter_mut(&mut self) -> hash_map::IterMut<'_, String, String> {
+        self.0.iter_mut()
+    }
+
+    #[cfg(test)]
+    pub fn raw_create(content: &[(&str, &str)]) -> Self {
+        RequestField(content.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect())
+    }
 }
 
 impl FromIterator<(String, String)> for RequestField {

--- a/curiefense/curieproxy/rust/luatests/test.lua
+++ b/curiefense/curieproxy/rust/luatests/test.lua
@@ -239,6 +239,14 @@ local function run_inspect_content_filter(raw_request_map)
     return response
 end
 
+local test_request = '{ "headers": { ":authority": "localhost:30081", ":method": "GET", ":path": "/dqsqsdqsdcqsd", "user-agent": "dummy", "x-forwarded-for": "12.13.14.15" }, "name": "test block by ip tagging", "response": { "action": "custom_response", "block_mode": true, "status": 503, "tags": [ "all", "geo:united-states", "ip:12-13-14-15", "sante", "securitypolicy-entry:default", "contentfiltername:default-contentfilter", "securitypolicy:default-entry", "aclname:default-acl", "aclid:--default--", "asn:7018", "tagbyip", "contentfilterid:--default--", "bot" ] } }'
+
+print("***  first request logs, check for configuration problems here ***")
+local response = run_inspect_request(json_decode(test_request))
+show_logs(cjson.decode(response)["logs"])
+print("*** done ***")
+print("")
+
 -- testing content filter only filtering
 local function test_content_filter(request_path)
   print("Testing " .. request_path)

--- a/curiefense/curieproxy/rust/luatests/test.lua
+++ b/curiefense/curieproxy/rust/luatests/test.lua
@@ -239,11 +239,16 @@ local function run_inspect_content_filter(raw_request_map)
     return response
 end
 
-local test_request = '{ "headers": { ":authority": "localhost:30081", ":method": "GET", ":path": "/dqsqsdqsdcqsd", "user-agent": "dummy", "x-forwarded-for": "12.13.14.15" }, "name": "test block by ip tagging", "response": { "action": "custom_response", "block_mode": true, "status": 503, "tags": [ "all", "geo:united-states", "ip:12-13-14-15", "sante", "securitypolicy-entry:default", "contentfiltername:default-contentfilter", "securitypolicy:default-entry", "aclname:default-acl", "aclid:--default--", "asn:7018", "tagbyip", "contentfilterid:--default--", "bot" ] } }'
+local test_request = '{ "headers": { ":authority": "localhost:30081", ":method": "GET", ":path": "/dqsqsdqsdcqsd"' ..
+  ', "user-agent": "dummy", "x-forwarded-for": "12.13.14.15" }, "name": "test block by ip tagging", "response": {' ..
+  '"action": "custom_response", "block_mode": true, "status": 503, "tags": [ "all", "geo:united-states", "ip:12-1' ..
+  '3-14-15", "sante", "securitypolicy-entry:default", "contentfiltername:default-contentfilter", "securitypolicy:' ..
+  'default-entry", "aclname:default-acl", "aclid:--default--", "asn:7018", "tagbyip", "contentfilterid:--default-' ..
+  '-", "bot" ] } }'
 
 print("***  first request logs, check for configuration problems here ***")
-local response = run_inspect_request(json_decode(test_request))
-show_logs(cjson.decode(response)["logs"])
+local tresponse = run_inspect_request(json_decode(test_request))
+show_logs(cjson.decode(tresponse)["logs"])
 print("*** done ***")
 print("")
 


### PR DESCRIPTION
This patch implements argument masking. In order to make sure no misuse
is possible, the inspection function takes ownership of the request
information structure, and returns a masked version.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>