### PR TITLE
Fix waf bypass bug

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/config/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/contentfilter.rs
@@ -160,6 +160,16 @@ fn mk_entry_match(
     em: RawContentFilterEntryMatch,
     content_filter_groups: &HashMap<String, ContentFilterGroup>,
 ) -> anyhow::Result<(String, ContentFilterEntryMatch)> {
+    let reg = match em.reg {
+        None => None,
+        Some(s) => {
+            if s.is_empty() {
+                None
+            } else {
+                Some(Regex::new(&s)?)
+            }
+        }
+    };
     Ok((
         em.key,
         ContentFilterEntryMatch {
@@ -181,7 +191,7 @@ fn mk_entry_match(
                 })
                 .flatten()
                 .collect::<HashSet<_>>(),
-            reg: em.reg.map(|s| Regex::new(&s)).transpose()?, // lol not Haskell
+            reg,
         },
     ))
 }

--- a/curiefense/curieproxy/rust/luatests/config/json/contentfilter-profiles.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/contentfilter-profiles.json
@@ -244,6 +244,37 @@
         }
     },
     {
+        "id": "maskall",
+        "name": "mask all arguments",
+        "ignore_alphanum": false,
+        "max_header_length": 1024,
+        "max_cookie_length": 1024,
+        "max_arg_length": 1024,
+        "max_headers_count": 42,
+        "max_cookies_count": 42,
+        "max_args_count": 3,
+        "args": {
+            "names": [],
+            "regex": [
+                {
+                    "key": ".*",
+                    "reg": "",
+                    "restrict": false,
+                    "mask": true,
+                    "exclusions": {}
+                }
+            ]
+        },
+        "headers": {
+            "names": [],
+            "regex": []
+        },
+        "cookies": {
+            "names": [],
+            "regex": []
+        }
+    },
+    {
         "id": "rr",
         "name": "rr",
         "ignore_alphanum": true,

--- a/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
@@ -82,6 +82,15 @@
                 "limit_ids": []
             },
             {
+                "match": "^/waf/maskall",
+                "name": "mask all tests",
+                "acl_profile": "__default__",
+                "content_filter_profile": "maskall",
+                "acl_active": true,
+                "content_filter_active": true,
+                "limit_ids": []
+            },
+            {
                 "match": "^/limits/simple",
                 "name": "limits simple",
                 "acl_profile": "__default__",

--- a/curiefense/curieproxy/rust/luatests/masking/all.json
+++ b/curiefense/curieproxy/rust/luatests/masking/all.json
@@ -1,0 +1,13 @@
+[
+  {
+    "headers": {
+      ":authority": "localhost:30081",
+      ":method": "GET",
+      ":path": "/waf/maskall?secret=SECRETSECRET",
+      "user-agent": "dummy",
+      "x-forwarded-for": "12.13.14.15"
+    },
+    "name": "url argument masking",
+    "secret": "SECRETSECRET"
+  }
+]

--- a/curiefense/curieproxy/rust/luatests/raw_requests/test-waf-mask.json
+++ b/curiefense/curieproxy/rust/luatests/raw_requests/test-waf-mask.json
@@ -1,0 +1,32 @@
+[
+  {
+    "response": {
+      "tags": [
+        "asn:396507",
+        "sante",
+        "ip:23-129-64-253",
+        "contentfilterid:maskall",
+        "contentfiltername:mask-all-arguments",
+        "container:1e219d8ed6b4",
+        "all",
+        "securitypolicy:default-entry",
+        "securitypolicy-entry:mask-all-tests",
+        "aclid:--default--",
+        "geo:united-states",
+        "bot",
+        "aclname:default-acl"
+      ],
+      "action": "custom_response",
+      "block_mode": true,
+      "status": 403
+    },
+    "name": "mask all",
+    "headers": {
+      "x-request-id": "e6acdce3-e076-4f0d-9a22-9d82fe01ba60",
+      "x-forwarded-for": "23.129.64.253",
+      ":path": "\/waf\/maskall?a=1&b=%3Cscript%3Edocument.body.innerHTML=",
+      ":method": "GET",
+      ":authority": "localhost:30081"
+    }
+  }
+]


### PR DESCRIPTION
In waf policies, a regex can be set to match values of arguments. When
this value is empty in the UI, it is stored as an empty string in the
configuration file. In that case, the resulting regex would be the empty
regex, matching everything.

This patch fixes that bug, and adds tests.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>