### PR TITLE
Remove validation tests of regex input fields

### DIFF
--- a/curiefense/ui/src/components/EntriesRelationList.vue
+++ b/curiefense/ui/src/components/EntriesRelationList.vue
@@ -535,13 +535,14 @@ export default Vue.extend({
     },
 
     validateRegex( id: string, value: string ) {
-      const val = value.trim().replaceAll(/\(\?[a-z]{1,3}\)/g, '') // remove unsupported in js mode modifiers
-      try {
-        this.clearError(id)
-        new RegExp(val)
-      } catch {
-        this.validate( val, /^[\w-]+$/, id )
-      }
+      // TODO: Fix regex test for rust standards and re-apply this
+      // const val = value.trim().replaceAll(/\(\?[a-z]{1,3}\)/g, '') // remove unsupported in js mode modifiers
+      // try {
+      //   this.clearError(id)
+      //   new RegExp(val)
+      // } catch {
+      //   this.validate( val, /^[\w-]+$/, id )
+      // }
     },
 
     validateNotEmpty( id: string, value: string ) {

--- a/curiefense/ui/src/components/__tests__/EntriesRelationList.spec.ts
+++ b/curiefense/ui/src/components/__tests__/EntriesRelationList.spec.ts
@@ -724,14 +724,15 @@ describe('EntriesRelationList.vue', () => {
       // check
       expect((wrapper.vm as any).duplicatedEntries.length).toEqual(1)
     })
-    test('should validate value as regex if category is path, query, or uri', async () => {
-      // change entry type to path
-      options.at(0).setSelected()
-      await Vue.nextTick()
-      newEntryTextarea.setValue('\\')
-      // check
-      expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
-    })
+    // TODO: Fix regex test for rust standards and re-apply this
+    // test('should validate value as regex if category is path, query, or uri', async () => {
+    //   // change entry type to path
+    //   options.at(0).setSelected()
+    //   await Vue.nextTick()
+    //   newEntryTextarea.setValue('\\')
+    //   // check
+    //   expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
+    // })
     test('should validate value as ip if category is ip', async () => {
       // change entry type to ip
       options.at(4).setSelected()
@@ -748,14 +749,15 @@ describe('EntriesRelationList.vue', () => {
       // check
       expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
     })
-    test('should validate second attribute if category is args, cookies, headers', async () => {
-      // change entry type to headers
-      options.at(7).setSelected()
-      await Vue.nextTick()
-      newEntrySecondAttr.setValue('\\')
-      // check
-      expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
-    })
+    // TODO: Fix regex test for rust standards and re-apply this
+    // test('should validate second attribute if category is args, cookies, headers', async () => {
+    //   // change entry type to headers
+    //   options.at(7).setSelected()
+    //   await Vue.nextTick()
+    //   newEntrySecondAttr.setValue('\\')
+    //   // check
+    //   expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
+    // })
     test('should clear errors', async () => {
       // change entry type to headers
       options.at(7).setSelected()

--- a/curiefense/ui/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/curiefense/ui/src/doc-editors/SecurityPoliciesEditor.vue
@@ -425,8 +425,10 @@ export default (Vue as VueConstructor<Vue & {
       const isDomainMatchDuplicate = this.domainNames.includes(
           newDomainMatch,
       ) ? this.initialDocDomainMatch !== newDomainMatch : false
-      const domainMatchContainsInvalidCharacters = !this.isURLValid(newDomainMatch)
-      return !isDomainMatchEmpty && !isDomainMatchDuplicate && !domainMatchContainsInvalidCharacters
+      // TODO: Fix regex test for rust standards and re-apply this
+      // const domainMatchContainsInvalidCharacters = !this.isURLValid(newDomainMatch)
+      // return !isDomainMatchEmpty && !isDomainMatchDuplicate && !domainMatchContainsInvalidCharacters
+      return !isDomainMatchEmpty && !isDomainMatchDuplicate
     },
 
     isSelectedMapEntryMatchValid(index: number): boolean {
@@ -437,8 +439,10 @@ export default (Vue as VueConstructor<Vue & {
         const isMapEntryMatchDuplicate = this.entriesMatchNames.includes(
             newMapEntryMatch,
         ) ? this.initialMapEntryMatch !== newMapEntryMatch : false
-        const mapEntryMatchContainsInvalidCharacters = !this.isURLValid(newMapEntryMatch.substring(1))
-        isValid = !isMapEntryMatchEmpty && !isMapEntryMatchDuplicate && !mapEntryMatchContainsInvalidCharacters
+        // TODO: Fix regex test for rust standards and re-apply this
+        // const mapEntryMatchContainsInvalidCharacters = !this.isURLValid(newMapEntryMatch.substring(1))
+        // isValid = !isMapEntryMatchEmpty && !isMapEntryMatchDuplicate && !mapEntryMatchContainsInvalidCharacters
+        isValid = !isMapEntryMatchEmpty && !isMapEntryMatchDuplicate
       }
       return isValid
     },

--- a/curiefense/ui/src/doc-editors/__tests__/SecurityPoliciesEditor.spec.ts
+++ b/curiefense/ui/src/doc-editors/__tests__/SecurityPoliciesEditor.spec.ts
@@ -504,14 +504,15 @@ describe('SecurityPoliciesEditor.vue', () => {
       expect(wrapper.emitted('form-invalid')[0]).toEqual([true])
     })
 
-    test('should emit form is invalid when filling match with illegal characters', async () => {
-      const input = wrapper.find('.document-domain-name');
-      (input.element as HTMLInputElement).value = 'БЮ'
-      input.trigger('input')
-      await Vue.nextTick()
-      expect(wrapper.emitted('form-invalid')).toBeTruthy()
-      expect(wrapper.emitted('form-invalid')[0]).toEqual([true])
-    })
+    // TODO: Fix regex test for rust standards and re-apply this
+    // test('should emit form is invalid when filling match with illegal characters', async () => {
+    //   const input = wrapper.find('.document-domain-name');
+    //   (input.element as HTMLInputElement).value = 'БЮ'
+    //   input.trigger('input')
+    //   await Vue.nextTick()
+    //   expect(wrapper.emitted('form-invalid')).toBeTruthy()
+    //   expect(wrapper.emitted('form-invalid')[0]).toEqual([true])
+    // })
 
     test('should emit form is valid when changing match to valid one', async () => {
       const input = wrapper.find('.document-domain-name');
@@ -551,19 +552,20 @@ describe('SecurityPoliciesEditor.vue', () => {
       expect(wrapper.emitted('form-invalid')[0]).toEqual([true])
     })
 
-    test('should emit form is invalid when filling map entry match with unacceptable characters', async () => {
-      const table = wrapper.find('.entries-table')
-      const entryRow = table.findAll('.entry-row').at(0)
-      entryRow.trigger('click')
-      await Vue.nextTick()
-      const currentEntryRow = table.findAll('.current-entry-row').at(0)
-      const entryMatch = currentEntryRow.find('.current-entry-match');
-      (entryMatch.element as HTMLInputElement).value = '/א'
-      entryMatch.trigger('input')
-      await Vue.nextTick()
-      expect(wrapper.emitted('form-invalid')).toBeTruthy()
-      expect(wrapper.emitted('form-invalid')[0]).toEqual([true])
-    })
+    // TODO: Fix regex test for rust standards and re-apply this
+    // test('should emit form is invalid when filling map entry match with unacceptable characters', async () => {
+    //   const table = wrapper.find('.entries-table')
+    //   const entryRow = table.findAll('.entry-row').at(0)
+    //   entryRow.trigger('click')
+    //   await Vue.nextTick()
+    //   const currentEntryRow = table.findAll('.current-entry-row').at(0)
+    //   const entryMatch = currentEntryRow.find('.current-entry-match');
+    //   (entryMatch.element as HTMLInputElement).value = '/א'
+    //   entryMatch.trigger('input')
+    //   await Vue.nextTick()
+    //   expect(wrapper.emitted('form-invalid')).toBeTruthy()
+    //   expect(wrapper.emitted('form-invalid')[0]).toEqual([true])
+    // })
 
     test('should emit form is valid when changing map entry match to valid one', async () => {
       const table = wrapper.find('.entries-table')


### PR DESCRIPTION
The validations are causing legal inputs to be marked as illegal and blocking save when they shouldn't, we'll need to reconfigure them correctly in the future
Add to-do notes on each removed code snippet

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>