### PR TITLE
Additonal improvements to Content Filters

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/v2/api.py
+++ b/curiefense/curieconf/server/curieconf/confserver/v2/api.py
@@ -101,6 +101,8 @@ m_contentfilterrule = api.model(
         "certainity": fields.Integer(required=True),
         "category": fields.String(required=True),
         "subcategory": fields.String(required=True),
+        "risk": fields.Integer(required=True),
+        "tags": fields.List(fields.String()),
     },
 )
 

--- a/curiefense/curieconf/server/curieconf/confserver/v2/json/content-filter-rule.schema
+++ b/curiefense/curieconf/server/curieconf/confserver/v2/json/content-filter-rule.schema
@@ -33,6 +33,12 @@
             "title": "Risk Level",
             "description": "Risk level of this rule, between 1 (lowest risk) and 5 (highest risk)"
         },
+        "tags": {
+            "title": "Tags List",
+            "description": "List of tags to apply",
+            "type": "array",
+            "items": { "type": "string" }
+        },
         "msg": {
             "type": "string",
             "title": "Message",

--- a/curiefense/ui/src/assets/DatasetsUtils.ts
+++ b/curiefense/ui/src/assets/DatasetsUtils.ts
@@ -58,6 +58,9 @@ const titles: { [key: string]: string } = {
   'flowcontrol-singular': 'Flow Control Policy',
   'contentfiltergroups': 'Content Filter Rules Groups',
   'contentfiltergroups-singular': 'Content Filter Rules Group',
+  'active': 'Active',
+  'report': 'Report',
+  'ignore': 'Ignore',
 }
 
 const limitOptionsTypes = {
@@ -251,6 +254,7 @@ const newDocEntryFactory: { [key: string]: Function } = {
       'operand': '',
       'category': '',
       'subcategory': '',
+      'tags': [],
     }
   },
 

--- a/curiefense/ui/src/components/AutocompleteInput.vue
+++ b/curiefense/ui/src/components/AutocompleteInput.vue
@@ -8,12 +8,12 @@
                 :title="title"
                 :placeholder="title"
                 class="autocomplete-input textarea is-small"
-                @keydown.enter="selectTextareaValue"
-                @keydown.space.prevent
-                @keydown.down="focusNextSuggestion"
-                @keydown.up="focusPreviousSuggestion"
-                @keydown.esc="closeDropdown"
-                @keydown.delete.prevent="onTextareaDelete"
+                @keyup.enter="selectTextareaValue"
+                @keyup.space.prevent
+                @keyup.down="focusNextSuggestion"
+                @keyup.up="focusPreviousSuggestion"
+                @keyup.esc="closeDropdown"
+                @keyup.delete.prevent="onTextareaDelete"
                 @input="onInput"
                 @blur="inputBlurred"
                 @focus="onTextareaFocus"
@@ -27,11 +27,11 @@
              class="autocomplete-input input is-small"
              aria-haspopup="true"
              aria-controls="dropdown-menu"
-             @keydown.enter="selectValue"
-             @keydown.space="selectValue"
-             @keydown.down="focusNextSuggestion"
-             @keydown.up="focusPreviousSuggestion"
-             @keydown.esc="closeDropdown"
+             @keyup.enter="selectValue"
+             @keyup.space="selectValue"
+             @keyup.down="focusNextSuggestion"
+             @keyup.up="focusPreviousSuggestion"
+             @keyup.esc="closeDropdown"
              @input="openDropdown(); valueChanged()"
              @blur="inputBlurred"
              ref="autocompleteInput" />
@@ -308,7 +308,7 @@ export default (Vue as VueConstructor<Vue & {
     },
 
     inputBlurred() {
-      // We would like to cancel and skip the selection if one of the following occoured:
+      // We would like to cancel and skip the selection if one of the following occurred:
       // * The blur is due to a suggestion click
       // * The component is destroyed before we finish selecting
       this.inputBlurredTimeout = setTimeout(() => {

--- a/curiefense/ui/src/components/EntriesRelationList.vue
+++ b/curiefense/ui/src/components/EntriesRelationList.vue
@@ -99,7 +99,7 @@
                              placeholder="Name"
                              @input="validateRegex( `${newEntryCategory}${sectionIndex}`, $event.target.value )"
                              v-model="newEntryItem.firstAttr"/>
-                      <span class="icon is-small is-left has-text-grey-light"><i class="fa fa-code"></i></span>
+                      <span class="icon is-small is-left has-text-grey-light"><i class="fa fa-font"></i></span>
                     </div>
                     <textarea v-else
                               title="Entries"

--- a/curiefense/ui/src/components/__tests__/AutocompleteInput.spec.ts
+++ b/curiefense/ui/src/components/__tests__/AutocompleteInput.spec.ts
@@ -144,7 +144,7 @@ describe('AutocompleteInput.vue', () => {
     input.setValue('value')
     input.trigger('input')
     wrapper.setData({focusedSuggestionIndex: 2})
-    input.trigger('keydown.enter')
+    input.trigger('keyup.enter')
     await Vue.nextTick()
     expect((input.element as HTMLInputElement).value).toEqual('')
   })
@@ -257,28 +257,28 @@ describe('AutocompleteInput.vue', () => {
     })
 
     test('should focus on next item when down arrow is pressed', async () => {
-      input.trigger('keydown.down')
+      input.trigger('keyup.down')
       await Vue.nextTick()
       expect(dropdownItems.at(0).element.classList.contains('is-active')).toBeTruthy()
     })
 
     test('should focus on previous item when up arrow is pressed', async () => {
       wrapper.setData({focusedSuggestionIndex: 2})
-      input.trigger('keydown.up')
+      input.trigger('keyup.up')
       await Vue.nextTick()
       expect(dropdownItems.at(1).element.classList.contains('is-active')).toBeTruthy()
     })
 
     test('should not focus on next item when down arrow is pressed if focused on last element', async () => {
       wrapper.setData({focusedSuggestionIndex: 2})
-      input.trigger('keydown.down')
+      input.trigger('keyup.down')
       await Vue.nextTick()
       expect(dropdownItems.at(2).element.classList.contains('is-active')).toBeTruthy()
     })
 
     test('should not focus on any item when up arrow is pressed if focused on input', async () => {
       wrapper.setData({focusedSuggestionIndex: -1})
-      input.trigger('keydown.up')
+      input.trigger('keyup.up')
       await Vue.nextTick()
       expect(dropdownItems.at(0).element.classList.contains('is-active')).toBeFalsy()
       expect(dropdownItems.at(1).element.classList.contains('is-active')).toBeFalsy()
@@ -287,7 +287,7 @@ describe('AutocompleteInput.vue', () => {
 
     test('should select focused suggestion when enter is pressed', async () => {
       wrapper.setData({focusedSuggestionIndex: 2})
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       await Vue.nextTick()
       expect((input.element as HTMLInputElement).value).toEqual('test-value-2')
     })
@@ -296,21 +296,21 @@ describe('AutocompleteInput.vue', () => {
       wrapper.setData({focusedSuggestionIndex: -1})
       input.setValue('test-value-1')
       input.trigger('input')
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       await Vue.nextTick()
       expect((input.element as HTMLInputElement).value).toEqual('test-value-1')
     })
 
     test('should emit selected value when enter is pressed', async () => {
       wrapper.setData({focusedSuggestionIndex: 2})
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       expect(wrapper.emitted('value-submitted')).toBeTruthy()
       expect(wrapper.emitted('value-submitted')[0]).toEqual(['test-value-2'])
     })
 
     test('should select focused suggestion when space is pressed', async () => {
       wrapper.setData({focusedSuggestionIndex: 2})
-      input.trigger('keydown.space')
+      input.trigger('keyup.space')
       await Vue.nextTick()
       expect((input.element as HTMLInputElement).value).toEqual('test-value-2')
     })
@@ -319,7 +319,7 @@ describe('AutocompleteInput.vue', () => {
       wrapper.setData({focusedSuggestionIndex: -1})
       input.setValue('test-value-1')
       input.trigger('input')
-      input.trigger('keydown.space')
+      input.trigger('keyup.space')
       await Vue.nextTick()
       expect((input.element as HTMLInputElement).value).toEqual('test-value-1')
     })
@@ -329,7 +329,7 @@ describe('AutocompleteInput.vue', () => {
       await Vue.nextTick()
       input.setValue('test-value-1')
       input.trigger('input')
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       await Vue.nextTick()
       expect(wrapper.emitted('value-submitted')).toBeTruthy()
     })
@@ -339,7 +339,7 @@ describe('AutocompleteInput.vue', () => {
       await Vue.nextTick()
       input.setValue('')
       input.trigger('input')
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       await Vue.nextTick()
       expect(wrapper.emitted('value-submitted')).toBeFalsy()
     })
@@ -349,7 +349,7 @@ describe('AutocompleteInput.vue', () => {
       await Vue.nextTick()
       input.setValue('t')
       input.trigger('input')
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       await Vue.nextTick()
       expect(wrapper.emitted('value-submitted')).toBeFalsy()
     })
@@ -363,7 +363,7 @@ describe('AutocompleteInput.vue', () => {
       await Vue.nextTick()
       input.setValue('')
       input.trigger('input')
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       await Vue.nextTick()
       expect(toastOutput.length).toEqual(0)
       jest.clearAllMocks()
@@ -384,7 +384,7 @@ describe('AutocompleteInput.vue', () => {
       await Vue.nextTick()
       input.setValue(selectedValue)
       input.trigger('input')
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       await Vue.nextTick()
       expect(toastOutput[0].message).toContain(failureMessage)
       expect(toastOutput[0].type).toContain(failureMessageClass)
@@ -393,7 +393,7 @@ describe('AutocompleteInput.vue', () => {
 
     test('should emit selected value when space is pressed', async () => {
       wrapper.setData({focusedSuggestionIndex: 2})
-      input.trigger('keydown.space')
+      input.trigger('keyup.space')
       expect(wrapper.emitted('value-submitted')).toBeTruthy()
       expect(wrapper.emitted('value-submitted')[0]).toEqual(['test-value-2'])
     })
@@ -406,7 +406,7 @@ describe('AutocompleteInput.vue', () => {
       (input.element as HTMLInputElement).value = 'test:CHECK-CASE_01'
       input.trigger('input')
       await Vue.nextTick()
-      input.trigger('keydown.space')
+      input.trigger('keyup.space')
       expect(wrapper.emitted('value-submitted')).toBeTruthy()
       expect(wrapper.emitted('value-submitted')[0]).toEqual(['test:check-case-01'])
     })
@@ -424,7 +424,7 @@ describe('AutocompleteInput.vue', () => {
     })
 
     test('should have dropdown hidden when esc is pressed', async () => {
-      input.trigger('keydown.esc')
+      input.trigger('keyup.esc')
       await Vue.nextTick()
       expect(wrapper.find('.dropdown').element.classList.contains('is-active')).toBeFalsy()
     })
@@ -455,14 +455,14 @@ describe('AutocompleteInput.vue', () => {
 
     test('should only change last word in input when selecting value with enter', async () => {
       wrapper.setData({focusedSuggestionIndex: 2})
-      input.trigger('keydown.enter')
+      input.trigger('keyup.enter')
       await Vue.nextTick()
       expect((input.element as HTMLInputElement).value).toEqual('devops test-value-2')
     })
 
     test('should only change last word in input when selecting value with space', async () => {
       wrapper.setData({focusedSuggestionIndex: 2})
-      input.trigger('keydown.space')
+      input.trigger('keyup.space')
       await Vue.nextTick()
       expect((input.element as HTMLInputElement).value).toEqual('devops test-value-2')
     })
@@ -563,17 +563,17 @@ describe('AutocompleteInput.vue', () => {
 
     test('should not add more than 1 new line when enter pressed', async () => {
       const textarea = wrapper.find('.autocomplete-input')
-      textarea.trigger('keydown.enter')
+      textarea.trigger('keyup.enter')
       await Vue.nextTick()
       expect(wrapper.emitted('value-submitted')).toBeTruthy()
       const event = {key: 'Enter', preventDefault: jest.fn()}
       const spy = jest.spyOn(event, 'preventDefault')
       textarea.setValue('1000\n')
-      textarea.trigger('keydown.enter', event)
+      textarea.trigger('keyup.enter', event)
       await Vue.nextTick()
       expect(spy).toHaveBeenCalled()
       textarea.setValue('')
-      textarea.trigger('keydown.enter', event)
+      textarea.trigger('keyup.enter', event)
       await Vue.nextTick()
       expect(spy).toHaveBeenCalled()
     })
@@ -594,7 +594,7 @@ describe('AutocompleteInput.vue', () => {
 
     test('should delete whole last line when delete pressed', async () => {
       const textarea = wrapper.find('.autocomplete-input')
-      textarea.trigger('keydown.delete')
+      textarea.trigger('keyup.delete')
       await Vue.nextTick()
       expect(wrapper.emitted('value-submitted')).toBeTruthy()
       expect(wrapper.emitted('value-submitted')[0]).toEqual(['1002\n1003'])

--- a/curiefense/ui/src/doc-editors/ContentFilterRulesEditor.vue
+++ b/curiefense/ui/src/doc-editors/ContentFilterRulesEditor.vue
@@ -33,6 +33,16 @@
                   </div>
                 </div>
                 <div class="field">
+                  <label class="label is-small">Tags</label>
+                  <div class="control">
+                    <input class="input is-small document-tags"
+                           title="Tags"
+                           placeholder="Tags"
+                           v-model="selectedDocTags"
+                           @change="emitDocUpdate()"/>
+                  </div>
+                </div>
+                <div class="field">
                   <label class="label is-small">Category</label>
                   <div class="control">
                     <input class="input is-small document-category"
@@ -116,6 +126,21 @@ export default Vue.extend({
   computed: {
     localDoc(): ContentFilterRule {
       return _.cloneDeep(this.selectedDoc)
+    },
+
+    selectedDocTags: {
+      get: function(): string {
+        if (this.localDoc.tags && this.localDoc.tags.length > 0) {
+          return this.localDoc.tags.join(' ')
+        }
+        return ''
+      },
+      set: function(tags: string): void {
+        this.localDoc.tags = tags.length > 0 ? _.map(tags.split(' '), (tag) => {
+          return tag.trim()
+        }) : []
+        this.emitDocUpdate()
+      },
     },
   },
   data() {

--- a/curiefense/ui/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
+++ b/curiefense/ui/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
@@ -76,6 +76,7 @@ describe('ContentFilterProfileEditor.vue', () => {
         'notes': '',
         'category': 'sqli',
         'subcategory': 'statement injection',
+        'tags': [],
       },
       {
         'id': '100001',
@@ -86,6 +87,7 @@ describe('ContentFilterProfileEditor.vue', () => {
         'notes': '',
         'operand': '\\s(and|or)\\s+["\']\\w+["\']\\s+.*between\\s.*["\']\\w+["\']\\s+and\\s+["\']\\w+.*',
         'msg': 'SQLi Attempt (Conditional Operator Detected)',
+        'tags': [],
       },
       {
         'id': '100002',
@@ -96,6 +98,7 @@ describe('ContentFilterProfileEditor.vue', () => {
         'notes': '',
         'operand': '\\W(\\s*)?(and|or)\\s.*(\'|").+(\'|")(\\s+)?(=|>|<|>=|<=).*(\'|").+',
         'msg': 'SQLi Attempt (Conditional Operator Detected)',
+        'tags': [],
       },
     ]
     contentFilterGroupsDocs = [

--- a/curiefense/ui/src/doc-editors/__tests__/ContentFilterRuleGroupEditor.spec.ts
+++ b/curiefense/ui/src/doc-editors/__tests__/ContentFilterRuleGroupEditor.spec.ts
@@ -13,15 +13,16 @@ describe('ContentFilterRuleGroupEditor.vue', () => {
   let selectedDoc: ContentFilterRuleGroup
   const ALL_RULES_NUMBER = 30
   const DOC_RULES_NUMBER = 25
-  const docExample = {
+  const docExample: ContentFilterRule = {
     'id': '100000',
     'name': '100000',
     'msg': 'SQLi Attempt (Conditional Operator Detected)',
     'operand': '\\s(and|or)\\s+\\d+\\s+.*between\\s.*\\d+\\s+and\\s+\\d+.*',
-    'severity': 5,
-    'certainity': 5,
+    'risk': 5,
+    'notes': 'SQL injection',
     'category': 'sqli',
     'subcategory': 'statement injection',
+    'tags': [],
   }
   const selectedBranch = 'master'
   beforeEach(() => {

--- a/curiefense/ui/src/doc-editors/__tests__/ContentFilterRulesEditor.spec.ts
+++ b/curiefense/ui/src/doc-editors/__tests__/ContentFilterRulesEditor.spec.ts
@@ -17,6 +17,7 @@ describe('ContentFilterRulesEditor.vue', () => {
       'notes': 'SQL injection',
       'category': 'sqli',
       'subcategory': 'statement injection',
+      'tags': [],
     }]
     wrapper = shallowMount(ContentFilterRulesEditor, {
       propsData: {

--- a/curiefense/ui/src/types/index.d.ts
+++ b/curiefense/ui/src/types/index.d.ts
@@ -71,6 +71,8 @@ declare module CuriefenseClient {
 
   type ACLProfileFilter = 'allow' | 'allow_bot' | 'deny_bot' | 'passthrough' | 'force_deny' | 'deny'
 
+  type ContentFilterProfileTagLists = 'active' | 'report' | 'ignore'
+
   type IncludeExcludeType = 'include' | 'exclude'
 
   type Relation = 'OR' | 'AND'
@@ -193,6 +195,7 @@ declare module CuriefenseClient {
     msg: string
     category: string
     subcategory: string
+    tags: string[]
   }
 
   type ContentFilterRuleGroup = {


### PR DESCRIPTION
Add missing properties risk and tag to Content Filter Rule schema and model
Add tag lists to Content Filter Profile named `active`, `report`, and `ignore`
Add masking_seed property to Content Filter Profile
Change autocomplete to submit on keyup rather than keydown as to avoid an "empty space" bug after submitting a value
Change icon in Global Filters to better reflect it is a text and not a regex field

TODO: Add Unit tests to the new content
Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>