### PR TITLE
Client improvements

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/v2/json/content-filter-profile.schema
+++ b/curiefense/curieconf/server/curieconf/confserver/v2/json/content-filter-profile.schema
@@ -41,11 +41,10 @@
                 "restrict": { "type": "boolean" },
                 "mask": { "type": "boolean" },
                 "exclusions": {
-                    "type": ["object", "null"],
-                    "additionalProperties": {
-                        "type": "string",
-                        "enum": ["rule", "group"]
-                    }
+                    "title": "Excluded Tags",
+                    "description": "List of excluded Content Filter tags",
+                    "type": "array",
+                    "items": { "type": "string" }
                 }
             }
         }

--- a/curiefense/ui/src/doc-editors/RateLimitsEditor.vue
+++ b/curiefense/ui/src/doc-editors/RateLimitsEditor.vue
@@ -96,8 +96,8 @@
                       </label>
                       <input class="input is-small document-limit"
                             type="text"
-                            title="A number of requests"
-                            placeholder="A number of requests"
+                            title="Number of events"
+                            placeholder="Number of events"
                             @change="emitDocUpdate"
                             v-model="threshold.limit">
                     </div>

--- a/curiefense/ui/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/curiefense/ui/src/doc-editors/SecurityPoliciesEditor.vue
@@ -312,7 +312,7 @@
                               <button title="Delete this profile"
                                       class="button is-small is-pulled-right is-danger is-light remove-entry-button"
                                       @click="removeMapEntry(mapIndex)"
-                                      v-if="localDoc.id !== '__default__' || initialMapEntryMatch !== '/'">
+                                      v-if="isRemoveEntryEnabled">
                                 Delete
                               </button>
                             </div>
@@ -389,6 +389,11 @@ export default (Vue as VueConstructor<Vue & {
       const isCurrentEntryMatchValid = this.mapEntryIndex === -1 ||
           this.isSelectedMapEntryMatchValid(this.mapEntryIndex)
       return !isDomainMatchValid || !isCurrentEntryMatchValid
+    },
+
+    isRemoveEntryEnabled(): boolean {
+      const isDefaultPath = (this.localDoc.id === '__default__' && this.initialMapEntryMatch === '/')
+      return this.localDoc.map.length > 1 && !isDefaultPath
     },
   },
 

--- a/curiefense/ui/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
+++ b/curiefense/ui/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
@@ -304,32 +304,17 @@ describe('ContentFilterProfileEditor.vue', () => {
   })
 
   test('should unpack exclusions correctly from model for view', async () => {
-    const unpackedExclusions = '1000 (Group)\n100000\n100001'
-    const packedExclusions = {
-      1000: 'group',
-      100000: 'rule',
-      100001: 'rule',
-    }
+    const unpackedExclusions = 'cf-rule-id:100000 cf-risk:5'
+    const packedExclusions = ['cf-rule-id:100000', 'cf-risk:5']
     const actualUnpackedExclusions = (wrapper.vm as any).unpackExclusions(packedExclusions)
     expect(actualUnpackedExclusions).toEqual(unpackedExclusions)
   })
 
   test('should unpack empty exclusions correctly from model for view', async () => {
     const unpackedExclusions = ''
-    const packedExclusions = {}
+    const packedExclusions: ContentFilterEntryMatch['exclusions'] = []
     const actualUnpackedExclusions = (wrapper.vm as any).unpackExclusions(packedExclusions)
     expect(actualUnpackedExclusions).toEqual(unpackedExclusions)
-  })
-
-  test('should remove nonexisting exclusions from model for view', async () => {
-    delete (wrapper.vm as any).contentFilter.group
-    const unpackedExclusions = (wrapper.vm as any).unpackExclusions({
-      1000: 'group',
-      100000: 'rule',
-      100001: 'rule',
-      900001: 'rule',
-    })
-    expect(unpackedExclusions).toEqual('100000\n100001')
   })
 
   buildTabDescribe('headers')
@@ -425,60 +410,14 @@ describe('ContentFilterProfileEditor.vue', () => {
           })
 
           test('should add exclusions when creating new parameter', async () => {
-            const wantedValue = {
-              1000: 'group',
-              100000: 'rule',
-              100001: 'rule',
-            }
+            const wantedValue = ['cf-rule-id:100001', 'cf-risk:3']
             const autocompleteInput = wrapper.findComponent(AutocompleteInput)
-            autocompleteInput.vm.$emit('value-submitted', '100000\n100001\n1000 (Group)')
+            autocompleteInput.vm.$emit('value-submitted', 'cf-rule-id:100001 cf-risk:3')
             await Vue.nextTick()
             const confirmButton = newRow.find('.confirm-add-new-parameter')
             confirmButton.trigger('click')
             await Vue.nextTick()
             const actualValue = (wrapper.vm as any).localDoc[tab][type][0].exclusions
-            expect(actualValue).toEqual(wantedValue)
-          })
-
-          test('should remove nonexisting exclusions when creating new parameter', async () => {
-            const wantedValue = {
-              1000: 'group',
-              100000: 'rule',
-            }
-            const autocompleteInput = wrapper.findComponent(AutocompleteInput)
-            autocompleteInput.vm.$emit('value-submitted', '100000\n9acf66222\n1000 (Group)\n900')
-            await Vue.nextTick()
-            const confirmButton = newRow.find('.confirm-add-new-parameter')
-            confirmButton.trigger('click')
-            await Vue.nextTick()
-            const actualValue = (wrapper.vm as any).localDoc[tab][type][0].exclusions
-            expect(actualValue).toEqual(wantedValue)
-          })
-
-          test('should have all suggestions passed to AutocompleteInput', async () => {
-            const wantedValue = [
-              {value: '100000'},
-              {value: '100001'},
-              {value: '100002'},
-              {value: '1000 (Group)'},
-              {value: '1001 (Group)'},
-            ]
-            const autocompleteInput = wrapper.findComponent(AutocompleteInput)
-            const actualValue = autocompleteInput.props('suggestions')
-            expect(actualValue).toEqual(wantedValue)
-          })
-
-          test('should have correct filtered suggestions passed to AutocompleteInput', async () => {
-            const existingRuleIDs = '100000\n100002'
-            const wantedValue = [
-              {value: '100001'},
-              {value: '1000 (Group)'},
-              {value: '1001 (Group)'},
-            ]
-            const autocompleteInput = wrapper.findComponent(AutocompleteInput)
-            autocompleteInput.vm.$emit('value-submitted', existingRuleIDs)
-            await Vue.nextTick()
-            const actualValue = autocompleteInput.props('suggestions')
             expect(actualValue).toEqual(wantedValue)
           })
 

--- a/curiefense/ui/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
+++ b/curiefense/ui/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
@@ -306,14 +306,14 @@ describe('ContentFilterProfileEditor.vue', () => {
   test('should unpack exclusions correctly from model for view', async () => {
     const unpackedExclusions = 'cf-rule-id:100000 cf-risk:5'
     const packedExclusions = ['cf-rule-id:100000', 'cf-risk:5']
-    const actualUnpackedExclusions = (wrapper.vm as any).unpackExclusions(packedExclusions)
+    const actualUnpackedExclusions = (wrapper.vm as any).exclusionsToString(packedExclusions)
     expect(actualUnpackedExclusions).toEqual(unpackedExclusions)
   })
 
   test('should unpack empty exclusions correctly from model for view', async () => {
     const unpackedExclusions = ''
     const packedExclusions: ContentFilterEntryMatch['exclusions'] = []
-    const actualUnpackedExclusions = (wrapper.vm as any).unpackExclusions(packedExclusions)
+    const actualUnpackedExclusions = (wrapper.vm as any).exclusionsToString(packedExclusions)
     expect(actualUnpackedExclusions).toEqual(unpackedExclusions)
   })
 

--- a/curiefense/ui/src/types/index.d.ts
+++ b/curiefense/ui/src/types/index.d.ts
@@ -12,15 +12,13 @@ declare module CuriefenseClient {
 
   // Document types helpers - START
 
-  type ContentFilterIgnoreType = 'rule' | 'group'
-
   type ContentFilterEntryMatch = {
     key: string
     reg: string
     restrict: boolean
     mask: boolean
     type: NamesRegexType
-    exclusions: { [key: string]: ContentFilterIgnoreType }
+    exclusions: string[]
   }
 
   type ContentFilterProfileSection = {

--- a/curiefense/ui/src/views/DocumentEditor.vue
+++ b/curiefense/ui/src/views/DocumentEditor.vue
@@ -272,11 +272,11 @@ export default Vue.extend({
       branches: 0,
 
       componentsMap: {
-        'aclprofiles': {component: ACLEditor},
-        'flowcontrol': {component: FlowControlPolicyEditor},
         'globalfilters': {component: GlobalFilterListEditor},
-        'ratelimits': {component: RateLimitsEditor},
+        'flowcontrol': {component: FlowControlPolicyEditor},
         'securitypolicies': {component: SecurityPoliciesEditor},
+        'ratelimits': {component: RateLimitsEditor},
+        'aclprofiles': {component: ACLEditor},
         'contentfilterprofiles': {component: ContentFilterEditor},
         'contentfilterrules': {component: ContentFilterRulesEditor},
       },

--- a/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
+++ b/curiefense/ui/src/views/__tests__/DocumentEditor.spec.ts
@@ -955,7 +955,7 @@ describe('DocumentEditor.vue', () => {
       // allow all requests to finish
       setImmediate(() => {
         const docTypeSelection = wrapper.find('.doc-type-selection')
-        expect((docTypeSelection.element as HTMLSelectElement).selectedIndex).toEqual(2)
+        expect((docTypeSelection.element as HTMLSelectElement).selectedIndex).toEqual(0)
         done()
       })
     })
@@ -985,7 +985,7 @@ describe('DocumentEditor.vue', () => {
         const branchSelection = wrapper.find('.branch-selection')
         expect((branchSelection.element as HTMLSelectElement).selectedIndex).toEqual(1)
         const docTypeSelection = wrapper.find('.doc-type-selection')
-        expect((docTypeSelection.element as HTMLSelectElement).selectedIndex).toEqual(0)
+        expect((docTypeSelection.element as HTMLSelectElement).selectedIndex).toEqual(4)
         const docSelection = wrapper.find('.doc-selection')
         expect((docSelection.element as HTMLSelectElement).selectedIndex).toEqual(1)
         done()
@@ -1003,7 +1003,7 @@ describe('DocumentEditor.vue', () => {
         const branchSelection = wrapper.find('.branch-selection')
         expect((branchSelection.element as HTMLSelectElement).selectedIndex).toEqual(0)
         const docTypeSelection = wrapper.find('.doc-type-selection')
-        expect((docTypeSelection.element as HTMLSelectElement).selectedIndex).toEqual(4)
+        expect((docTypeSelection.element as HTMLSelectElement).selectedIndex).toEqual(2)
         const docSelection = wrapper.find('.doc-selection')
         expect((docSelection.element as HTMLSelectElement).selectedIndex).toEqual(0)
         done()
@@ -1021,7 +1021,7 @@ describe('DocumentEditor.vue', () => {
         const branchSelection = wrapper.find('.branch-selection')
         expect((branchSelection.element as HTMLSelectElement).selectedIndex).toEqual(0)
         const docTypeSelection = wrapper.find('.doc-type-selection')
-        expect((docTypeSelection.element as HTMLSelectElement).selectedIndex).toEqual(0)
+        expect((docTypeSelection.element as HTMLSelectElement).selectedIndex).toEqual(4)
         const docSelection = wrapper.find('.doc-selection')
         expect((docSelection.element as HTMLSelectElement).selectedIndex).toEqual(0)
         done()
@@ -1316,7 +1316,7 @@ describe('DocumentEditor.vue', () => {
       const docTypeSelection = wrapper.find('.doc-type-selection')
       docTypeSelection.trigger('click')
       const docTypeOptions = docTypeSelection.findAll('option')
-      docTypeOptions.at(2).setSelected()
+      docTypeOptions.at(0).setSelected()
       // allow all requests to finish
       setImmediate(() => {
         // switch to a different document
@@ -1383,7 +1383,7 @@ describe('DocumentEditor.vue', () => {
       const docTypeSelection = wrapper.find('.doc-type-selection')
       docTypeSelection.trigger('click')
       const options = docTypeSelection.findAll('option')
-      options.at(4).setSelected()
+      options.at(2).setSelected()
       // allow all requests to finish
       setImmediate(async () => {
         const originalDoc = (wrapper.vm as any).selectedDoc


### PR DESCRIPTION
Change CF Profile exclusion text from “Rule or group name” to “Content filter rules tags” and from “Ignore Content Filter” to “Ignore Content Filter Tags”
Change CF Profile exclusion from map to list of tags
Add check to prevent the user from deleting the last path in a Security Policy
Change Rate Limit Rule text from “A number of requests” to “Number of events”
Change order of documents in “Policies & Rules” dropdown to better reflect the flow of a request in the system

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>