### PR TITLE
New compose file: with juicebox

### DIFF
--- a/curiefense/images/curieproxy-nginx/conf.d/default.template
+++ b/curiefense/images/curieproxy-nginx/conf.d/default.template
@@ -3,7 +3,7 @@ lua_package_path '/lua/?.lua;;';
 log_format curiefenselog escape=none '$request_map';
 
 upstream backend {
-    server echo:8080;
+    server ${TARGET_ADDRESS}:${TARGET_PORT};
 }
 
 server {
@@ -28,6 +28,5 @@ server {
             session.log(ngx)
         }
         proxy_pass http://backend;
-        # proxy_pass http://echo:8080;
     }
 }

--- a/curiefense/images/curieproxy-nginx/start.sh
+++ b/curiefense/images/curieproxy-nginx/start.sh
@@ -3,4 +3,6 @@
 rm -f /run/rsyslogd.pid
 rsyslogd -n &
 
+# shellcheck disable=SC2016
+envsubst '${TARGET_ADDRESS},${TARGET_PORT}' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf
 /usr/local/openresty/bin/openresty -g "daemon off;"

--- a/deploy/compose/docker-compose-full.yaml
+++ b/deploy/compose/docker-compose-full.yaml
@@ -3,7 +3,7 @@ services:
   curieproxy:
     container_name: curieproxy
     hostname: curieproxy
-    image: "curiefense/curieproxy-nginx:${DOCKER_TAG}"
+    image: "curiefense/curieproxy-envoy:${DOCKER_TAG}"
     restart: always
     volumes:
       - curieproxy_config:/cf-config
@@ -12,6 +12,56 @@ services:
       - TARGET_ADDRESS=echo
       - TARGET_PORT=8080
       - XFF_TRUSTED_HOPS
+      - ENVOY_LOG_LEVEL
+    networks:
+      curiemesh:
+        aliases:
+          - curieproxy
+    ports:
+      - "30081:80"
+      - "30444:443"
+      - "8001:8001"
+    secrets:
+      - curieproxysslcrt
+      - curieproxysslkey
+
+  curieproxyjuice:
+    container_name: curieproxyjuice
+    hostname: curieproxyjuice
+    image: "curiefense/curieproxy-envoy:${DOCKER_TAG}"
+    restart: always
+    volumes:
+      - curieproxy_config:/cf-config
+    environment:
+      - ENVOY_UID
+      - TARGET_ADDRESS=juiceshop
+      - TARGET_PORT=3000
+      - XFF_TRUSTED_HOPS
+      - ENVOY_LOG_LEVEL
+    networks:
+      curiemesh:
+        aliases:
+          - curieproxy
+    ports:
+      - "30071:80"
+      - "30434:443"
+    secrets:
+      - curieproxysslcrt
+      - curieproxysslkey
+
+  curieproxyngx:
+    container_name: curieproxyngx
+    hostname: curieproxyngx
+    image: "curiefense/curieproxy-nginx:${DOCKER_TAG}"
+    restart: always
+    volumes:
+      - curieproxy_config:/cf-config
+    environment:
+      - ENVOY_UID
+      - XFF_TRUSTED_HOPS
+      - JUICE=yes
+      - TARGET_ADDRESS=juiceshop
+      - TARGET_PORT=3000
     networks:
       curiemesh:
         aliases:
@@ -19,10 +69,22 @@ services:
     ports:
       - "30082:30082"
       - "30083:30083"
-      - "8001:8001"
     secrets:
       - curieproxysslcrt
       - curieproxysslkey
+
+  juiceshop:
+    container_name: juiceshop
+    hostname: juiceshop
+    image: "bkimminich/juice-shop"
+    restart: always
+    tty: true
+    networks:
+      curiemesh:
+        aliases:
+          - curieproxy
+    ports:
+      - "3000:3000"
 
   confserver:
     container_name: confserver
@@ -65,14 +127,6 @@ services:
       - s3cfg
 #      - gc
 #      - azr
-
-  curietasker:
-    container_name: curietasker
-    hostname: curietasker
-    image: "curiefense/curietasker:${DOCKER_TAG}"
-    restart: always
-    networks:
-      - confnet
 
   redis:
     container_name: redis
@@ -151,6 +205,7 @@ services:
     restart: always
     volumes:
       - persistent_grafana:/var/lib/grafana
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
     networks:
       - curiemesh
       - confnet
@@ -160,7 +215,7 @@ services:
   elasticsearch:
     container_name: elasticsearch
     hostname: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.3
     restart: always
     volumes:
       - persistent_elasticsearch:/usr/share/elasticsearch/data
@@ -182,7 +237,7 @@ services:
   kibana:
     container_name: kibana
     hostname: kibana
-    image: docker.elastic.co/kibana/kibana:7.10.1
+    image: docker.elastic.co/kibana/kibana:7.13.3
     restart: always
     environment:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
@@ -196,7 +251,7 @@ services:
 
   filebeat:
     container_name: filebeat
-    image: docker.elastic.co/beats/filebeat:7.10.1
+    image: docker.elastic.co/beats/filebeat:7.13.3
     command: >
         bash -c "
         for i in {1..40}; do
@@ -209,6 +264,7 @@ services:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
       - KIBANA_URL=http://kibana:5601
     volumes:
+      - ./elk/7_x/dashboards.json:/usr/share/filebeat/curiefense/7/dashboard/dashboards.json
       - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml
       - ./filebeat/ilm.json:/usr/share/filebeat/ilm.json
       - ./filebeat/template.json:/usr/share/filebeat/template.json


### PR DESCRIPTION
In a single compose file, you now have:

 * a vulnerable application, juicebox, listening on port 3000;
 * the "vanilla" envoy proxy, with the echo backend (port 30081);
 * the "vulnerable" envoy proxy, with the juicebox backend (port 30071);
 * the "vulnerable" nginx proxy, with the juicebox backend (port 30082).

Signed-off-by: Simon Marechal <bartavelle@gmail.com>