### PR TITLE
curieproxy-envoy: update to v1.21.1

### DIFF
--- a/curiefense/images/curieproxy-envoy/Dockerfile
+++ b/curiefense/images/curieproxy-envoy/Dockerfile
@@ -1,7 +1,7 @@
 ARG RUSTBIN_TAG=latest
 FROM curiefense/curiefense-rustbuild-bionic:${RUSTBIN_TAG} AS rustbin
-FROM curiefense/envoy-cf:0250ad715e8c0463d0d4389cbfab340bc7dd7587 AS envoy-cf
-FROM envoyproxy/envoy:v1.16.5
+FROM curiefense/envoy-cf:15d1607b3035c900ea943ac8e1fed6f15598a46b AS envoy-cf
+FROM envoyproxy/envoy:v1.21.1
 
 RUN apt-get update && \
     apt-get -qq -y --no-install-recommends install jq luarocks libpcre2-dev libgeoip-dev \


### PR DESCRIPTION
Istio 1.13.2 also uses envoy 1.21.1.

Signed-off-by: Xavier <xavier@reblaze.com>