### PR TITLE
Avoid formatting strings when unnecessary in the logs API

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/config/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/contentfilter.rs
@@ -248,7 +248,7 @@ impl ContentFilterProfile {
                 Ok((k, v)) => {
                     out.insert(k, v);
                 }
-                Err(rr) => logs.error(format!("content filter id {}: {:?}", id, rr)),
+                Err(rr) => logs.error(|| format!("content filter id {}: {:?}", id, rr)),
             }
         }
         out
@@ -342,10 +342,10 @@ pub fn resolve_rules(
     for v in profiles.values() {
         match build_from_profile(v) {
             Ok(p) => {
-                logs.debug(format!("Loaded profile {} with {} rules", v.id, p.ids.len()));
+                logs.debug(|| format!("Loaded profile {} with {} rules", v.id, p.ids.len()));
                 out.insert(v.id.to_string(), p);
             }
-            Err(rr) => logs.error(format!("When building profile {}, error: {}", v.id, rr)),
+            Err(rr) => logs.error(|| format!("When building profile {}, error: {}", v.id, rr)),
         }
     }
 

--- a/curiefense/curieproxy/rust/curiefense/src/config/flow.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/flow.rs
@@ -109,7 +109,7 @@ pub fn flow_resolve(logs: &mut Logs, rawentries: Vec<RawFlowEntry>) -> HashMap<S
             continue;
         }
         match FlowEntry::convert(rawentry) {
-            Err(rr) => logs.warning(rr),
+            Err(rr) => logs.warning(|| rr.to_string()),
             Ok(entry) => {
                 let nsteps = entry.sequence.len();
                 for (stepid, step) in entry.sequence.into_iter().enumerate() {

--- a/curiefense/curieproxy/rust/curiefense/src/config/globalfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/globalfilter.rs
@@ -220,7 +220,7 @@ impl GlobalFilterSection {
                         re: match Regex::new(s) {
                             Ok(r) => Some(r),
                             Err(rr) => {
-                                logs.error(format!("Bad regex {}: {}", s, rr));
+                                logs.error(|| format!("Bad regex {}: {}", s, rr));
                                 None
                             }
                         },
@@ -247,7 +247,7 @@ impl GlobalFilterSection {
                         re: match Regex::new(&v) {
                             Ok(r) => Some(r),
                             Err(rr) => {
-                                logs.error(format!("Bad regex {}: {}", v, rr));
+                                logs.error(|| format!("Bad regex {}: {}", v, rr));
                                 None
                             }
                         },
@@ -261,7 +261,7 @@ impl GlobalFilterSection {
                         re: match Regex::new(nval) {
                             Ok(r) => Some(r),
                             Err(rr) => {
-                                logs.error(format!("Bad regex {}: {}", nval, rr));
+                                logs.error(|| format!("Bad regex {}: {}", nval, rr));
                                 None
                             }
                         },
@@ -344,7 +344,7 @@ impl GlobalFilterSection {
 
         for rgf in rawglobalfilters.into_iter().filter(|s| s.active) {
             match convert_section(logs, rgf) {
-                Err(rr) => logs.error(rr),
+                Err(rr) => logs.error(|| rr.to_string()),
                 Ok(gfilter) => out.push(gfilter),
             }
         }

--- a/curiefense/curieproxy/rust/curiefense/src/config/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/limit.rs
@@ -86,7 +86,7 @@ impl Limit {
                 Ok((nm, lm)) => {
                     out.insert(nm, lm);
                 }
-                Err(rr) => logs.error(format!("limit id {}: {:?}", curid, rr)),
+                Err(rr) => logs.error(|| format!("limit id {}: {:?}", curid, rr)),
             }
         }
         out

--- a/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
@@ -191,11 +191,11 @@ pub fn content_filter_check(
                 &profile.ignore,
                 &omit.exclusions,
             ) {
-                logs.error(rr)
+                logs.error(|| rr.to_string())
             }
         }
         None => {
-            logs.warning(format!("no hsdb found for profile {}, it probably means that no rules were matched by the active/report/ignore", profile.id));
+            logs.warning(||format!("no hsdb found for profile {}, it probably means that no rules were matched by the active/report/ignore", profile.id));
         }
     }
 
@@ -237,7 +237,7 @@ fn section_check(
         if section.max_count > 0 {
             return Err(ContentFilterBlock::TooManyEntries(idx));
         } else {
-            logs.warning(format!("In section {:?}, param_count = 0", idx));
+            logs.warning(|| format!("In section {:?}, param_count = 0", idx));
         }
     }
 
@@ -247,7 +247,7 @@ fn section_check(
             if section.max_length > 0 {
                 return Err(ContentFilterBlock::EntryTooLarge(idx, name.to_string()));
             } else {
-                logs.warning(format!("In section {:?}, max_length = 0", idx));
+                logs.warning(|| format!("In section {:?}, max_length = 0", idx));
             }
         }
 
@@ -362,7 +362,7 @@ fn hyperscan(
         found = true;
         Matching::Continue
     })?;
-    logs.debug(format!("matching content filter signatures: {}", found));
+    logs.debug(|| format!("matching content filter signatures: {}", found));
 
     if !found {
         return Ok(());
@@ -372,9 +372,9 @@ fn hyperscan(
     for (k, (sid, name)) in hca_keys {
         sigs.db.scan(&[k.as_bytes()], &scratch, |id, _, _, _| {
             match sigs.ids.get(id as usize) {
-                None => logs.error(format!("INVALID INDEX ??? {}", id)),
+                None => logs.error(|| format!("Should not happen, invalid hyperscan index {}", id)),
                 Some(sig) => {
-                    logs.debug(format!("signature matched {:?}", sig));
+                    logs.debug(|| format!("signature matched {:?}", sig));
 
                     // new specific tags are singleton hashsets, but we use the Tags structure to make sure
                     // they are properly converted

--- a/curiefense/curieproxy/rust/curiefense/src/flow.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/flow.rs
@@ -93,7 +93,7 @@ async fn ban_react<CNX: redis::aio::ConnectionLike>(
     let ban_key = get_ban_key(redis_key);
     let banned = is_banned(cnx, &ban_key).await;
     if banned {
-        logs.debug(format!("Key {} is banned!", ban_key));
+        logs.debug(|| format!("Key {} is banned!", ban_key));
     }
     if banned || blocked {
         let action = extract_bannable_action(
@@ -142,7 +142,7 @@ pub async fn flow_check(
                 if !flow_match(reqinfo, tags, elem) {
                     continue;
                 }
-                logs.debug(format!("Testing flow control {} (step {})", elem.name, elem.step));
+                logs.debug(|| format!("Testing flow control {} (step {})", elem.name, elem.step));
                 match build_redis_key(reqinfo, tags, &elem.key, &elem.id, &elem.name) {
                     Some(redis_key) => {
                         match check_flow(&mut cnx, &redis_key, elem.step, elem.timeframe, elem.is_last).await? {
@@ -157,7 +157,7 @@ pub async fn flow_check(
                             FlowResult::NonLast => {}
                         }
                     }
-                    None => logs.warning(format!("Could not fetch key in flow control {}", elem.name)),
+                    None => logs.warning(|| format!("Could not fetch key in flow control {}", elem.name)),
                 }
             }
             Ok(bad)

--- a/curiefense/curieproxy/rust/curiefense/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/lib.rs
@@ -31,7 +31,7 @@ use utils::{map_request, RawRequest, RequestInfo};
 fn challenge_verified<GH: Grasshopper>(gh: &GH, reqinfo: &RequestInfo, logs: &mut Logs) -> bool {
     if let Some(rbzid) = reqinfo.cookies.get("rbzid") {
         if let Some(ua) = reqinfo.headers.get("user-agent") {
-            logs.debug(format!("Checking rbzid cookie {} with user-agent {}", rbzid, ua));
+            logs.debug(|| format!("Checking rbzid cookie {} with user-agent {}", rbzid, ua));
             return match gh.parse_rbzid(&rbzid.replace('-', "="), ua) {
                 Some(b) => b,
                 None => {
@@ -89,7 +89,7 @@ pub async fn inspect_generic_request_map_async<GH: Grasshopper>(
     // insert the all tag here, to make sure it is always present, even in the presence of early errors
     tags.insert("all");
 
-    logs.debug(format!("Inspection starts (grasshopper active: {})", mgh.is_some()));
+    logs.debug(|| format!("Inspection starts (grasshopper active: {})", mgh.is_some()));
 
     // do all config queries in the lambda once
     // there is a lot of copying taking place, to minimize the lock time
@@ -175,7 +175,7 @@ pub fn content_filter_check_generic_request_map(
     let waf_result = match HSDB.read() {
         Ok(rd) => content_filter_check(logs, &mut tags, &reqinfo, &waf_profile, rd.get(content_filter_id)),
         Err(rr) => {
-            logs.error(format!("Could not get lock on HSDB: {}", rr));
+            logs.error(|| format!("Could not get lock on HSDB: {}", rr));
             Ok(())
         }
     };

--- a/curiefense/curieproxy/rust/curiefense/src/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/limit.rs
@@ -106,7 +106,7 @@ pub async fn limit_check(
     let mut redis = match redis_async_conn().await {
         Ok(c) => c,
         Err(rr) => {
-            logs.error(format!("Could not connect to the redis server {}", rr));
+            logs.error(|| format!("Could not connect to the redis server {}", rr));
             return SimpleDecision::Pass;
         }
     };
@@ -115,7 +115,7 @@ pub async fn limit_check(
 
     for limit in limits {
         if !limit_match(tags, limit) {
-            logs.debug(format!("limit {} excluded", limit.name));
+            logs.debug(|| format!("limit {} excluded", limit.name));
             continue;
         }
 
@@ -126,7 +126,7 @@ pub async fn limit_check(
             Some(k) => k,
         };
         let ban_key = get_ban_key(&key);
-        logs.debug(format!("limit={:?} key={}", limit, key));
+        logs.debug(|| format!("limit={:?} key={}", limit, key));
 
         if is_banned(&mut redis, &ban_key).await {
             logs.debug("is banned!");
@@ -162,7 +162,7 @@ pub async fn limit_check(
         };
 
         match redis_get_limit(&mut redis, &key, limit.timeframe, pairvalue).await {
-            Err(rr) => logs.error(rr),
+            Err(rr) => logs.error(|| rr.to_string()),
             Ok(current_count) => {
                 for threshold in &limit.thresholds {
                     // Only one action with highest limit larger than current

--- a/curiefense/curieproxy/rust/curiefense/src/redis.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/redis.rs
@@ -38,7 +38,7 @@ pub async fn extract_bannable_action<CNX: redis::aio::ConnectionLike>(
     ban_status: BanStatus,
 ) -> SimpleAction {
     if let SimpleActionT::Ban(subaction, duration) = &action.atype {
-        logs.info(format!("Banned key {} for {}s", redis_key, duration));
+        logs.info(|| format!("Banned key {} for {}s", redis_key, duration));
         match ban_status {
             BanStatus::AlreadyBanned => (),
             BanStatus::NewBan => {

--- a/curiefense/curieproxy/rust/curiefense/src/securitypolicy.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/securitypolicy.rs
@@ -21,7 +21,7 @@ pub fn match_securitypolicy<'a>(
         .find(|e| e.matches(host))
         .map(|m| &m.inner)
         .or(cfg.default.as_ref())?;
-    logs.debug(format!("Selected hostmap {}", hostmap.name));
+    logs.debug(|| format!("Selected hostmap {}", hostmap.name));
     // find the first matching securitypolicy, or use the default, if it exists
     let securitypolicy: &SecurityPolicy = match hostmap
         .entries
@@ -36,6 +36,6 @@ pub fn match_securitypolicy<'a>(
         }
         Some(x) => x,
     };
-    logs.debug(format!("Selected hostmap entry {}", securitypolicy.name));
+    logs.debug(|| format!("Selected hostmap entry {}", securitypolicy.name));
     Some((hostmap.name.clone(), securitypolicy))
 }

--- a/curiefense/curieproxy/rust/curiefense/src/utils.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/utils.rs
@@ -86,7 +86,7 @@ fn map_args(
 
     let body_decoding = if let Some(body) = mbody {
         if let Err(rr) = parse_body(logs, &mut args, mcontent_type, accepted_types, body) {
-            logs.debug(format!("Body parsing failed: {}", rr));
+            logs.debug(|| format!("Body parsing failed: {}", rr));
             // if the body could not be parsed, store it in an argument, as if it was text
             args.add(
                 "RAW_BODY".to_string(),
@@ -315,7 +315,7 @@ pub fn find_geoip(logs: &mut Logs, ipstr: String) -> GeoIp {
     let ip = match pip {
         Ok(x) => x,
         Err(rr) => {
-            logs.error(format!("When parsing ip {}", rr));
+            logs.error(|| format!("When parsing ip {}", rr));
             return geoip;
         }
     };
@@ -366,7 +366,7 @@ pub fn find_geoip(logs: &mut Logs, ipstr: String) -> GeoIp {
                     geoip.region = region.iso_code.map(|s| s.to_string());
                     geoip.subregion = subregion.iso_code.map(|s| s.to_string());
                 }
-                _ => logs.error(format!("Too many subdivisions were reported for {}", ip)),
+                _ => logs.error(|| format!("Too many subdivisions were reported for {}", ip)),
             }
         }
         geoip.city_name = cty.city.as_ref().and_then(|c| get_name(&c.names));


### PR DESCRIPTION
This patch defers string building until it is known to be useful for
logging.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>