### PR TITLE
manual docker build

### DIFF
--- a/.github/workflows/curiefense-build-images.yml
+++ b/.github/workflows/curiefense-build-images.yml
@@ -1,6 +1,7 @@
 name: Publish docker images
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -10,7 +11,7 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
-
+    environment: prod
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/curiefense-build-images.yml
+++ b/.github/workflows/curiefense-build-images.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/curiefense-manual-build-image.yml
+++ b/.github/workflows/curiefense-manual-build-image.yml
@@ -1,15 +1,12 @@
-name: Publish docker images
+name: Manual publish docker images
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'curiefense/**'
+  workflow_dispatch:
 
 jobs:
   push:
     runs-on: ubuntu-latest
+    environment: prod
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/curiefense-manual-build-image.yml
+++ b/.github/workflows/curiefense-manual-build-image.yml
@@ -1,11 +1,12 @@
 name: Manual publish docker images
 
 on:
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   push:
     runs-on: ubuntu-latest
+
     environment: prod
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add the ability to manually run the docker-push workflow.

Environment is set to "prod", which requires an approver.
Approver list can be found here:

https://github.com/curiefense/curiefense/settings/environments/470027045/edit