### PR TITLE
Redis connection settings customization

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/redis.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/redis.rs
@@ -3,6 +3,7 @@ use crate::{
     logs::Logs,
 };
 use lazy_static::lazy_static;
+use redis::{ConnectionAddr, ConnectionInfo, RedisConnectionInfo};
 
 lazy_static! {
     static ref RPOOL: anyhow::Result<redis::aio::ConnectionManager> = async_std::task::block_on(build_pool());
@@ -11,7 +12,18 @@ lazy_static! {
 /// creates an async connection to a redis server
 pub async fn build_pool() -> anyhow::Result<redis::aio::ConnectionManager> {
     let server = std::env::var("REDIS_HOST").unwrap_or_else(|_| "redis".to_string());
-    let client = redis::Client::open(format!("redis://{}:6379/", server))?;
+    let port = std::env::var("REDIS_PORT").unwrap_or_else(|_| "6379".to_string());
+    let db = std::env::var("REDIS_DB").unwrap_or_else(|_| "0".to_string());
+    let username = std::env::var("REDIS_USERNAME").ok();
+    let password = std::env::var("REDIS_PASSWORD").ok();
+    let addr = ConnectionAddr::Tcp(server, port.parse()?);
+    let redis = RedisConnectionInfo {
+        db: db.parse()?,
+        username,
+        password,
+    };
+    let cinfo = ConnectionInfo { addr, redis };
+    let client = redis::Client::open(cinfo)?;
     let o = redis::aio::ConnectionManager::new(client).await?;
     Ok(o)
 }


### PR DESCRIPTION
This patch makes it possible to configure the Redis server data using
the following environment variables:

 * REDIS_HOST (defaults to `redis`), previously available ;
 * REDIS_PORT (defaults to `6379`) ;
 * REDIS_DB (defaults to `0`) ;
 * REDIS_USERNAME (optional) ;
 * REDIS_PASSWORD (optional).

Should fix #816 

Signed-off-by: Simon Marechal <bartavelle@gmail.com>