### PR TITLE
Body size and depth restrictions

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/benches/body_parse.rs
+++ b/curiefense/curieproxy/rust/curiefense/benches/body_parse.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 fn body_test(mcontent_type: Option<&str>, body: &[u8], expected_size: Option<usize>) {
     let mut logs = Logs::default();
     let mut args = RequestField::new(&[]);
-    parse_body(&mut logs, &mut args, mcontent_type, &[], body).unwrap();
+    parse_body(&mut logs, &mut args, 500, mcontent_type, &[], body).unwrap();
     if let Some(sz) = expected_size {
         assert_eq!(args.len(), sz);
     }

--- a/curiefense/curieproxy/rust/curiefense/src/config/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/contentfilter.rs
@@ -33,6 +33,8 @@ pub struct ContentFilterProfile {
     pub decoding: Vec<Transformation>,
     pub masking_seed: Vec<u8>,
     pub content_type: Vec<ContentType>,
+    pub max_body_size: usize,
+    pub max_body_depth: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,6 +83,8 @@ impl ContentFilterProfile {
             ignore: HashSet::default(),
             report: HashSet::default(),
             content_type: Vec::new(),
+            max_body_size: usize::MAX,
+            max_body_depth: usize::MAX,
         }
     }
 }
@@ -235,6 +239,8 @@ fn convert_entry(entry: RawContentFilterProfile) -> anyhow::Result<(String, Cont
             ignore: entry.ignore.into_iter().collect(),
             report: entry.report.into_iter().collect(),
             content_type: entry.content_type,
+            max_body_size: entry.max_body_size.unwrap_or(usize::MAX),
+            max_body_depth: entry.max_body_depth.unwrap_or(usize::MAX),
         },
     ))
 }

--- a/curiefense/curieproxy/rust/curiefense/src/config/raw.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/raw.rs
@@ -277,6 +277,8 @@ pub struct RawContentFilterProfile {
     pub masking_seed: String,
     #[serde(default)]
     pub content_type: Vec<ContentType>,
+    pub max_body_size: Option<usize>,
+    pub max_body_depth: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
@@ -475,7 +475,7 @@ mod test {
             headers,
             meta,
         };
-        map_request(&mut logs, &[], &[], &raw_request)
+        map_request(&mut logs, &[], &[], 500, &raw_request)
     }
 
     #[test]

--- a/curiefense/curieproxy/rust/curiefense/src/incremental.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/incremental.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 
 use crate::{
     analyze::analyze,
+    body::body_too_large,
     challenge_verified,
     config::{
         contentfilter::SectionIdx,
@@ -20,7 +21,7 @@ use crate::{
     },
     contentfilter::ContentFilterBlock,
     grasshopper::Grasshopper,
-    interface::{Decision, Tags},
+    interface::{Action, Decision, Tags},
     logs::{LogLevel, Logs},
     securitypolicy::match_securitypolicy,
     tagging::tag_request,
@@ -64,7 +65,7 @@ pub fn inspect_init(
 
 /// called when the content filter policy is violated
 /// no tags are returned though!
-fn early_block(idata: IData, block: ContentFilterBlock) -> (Decision, Tags, RequestInfo) {
+fn early_block(idata: IData, action: Action) -> (Decision, Tags, RequestInfo) {
     let mut logs = idata.logs;
     let secpolicy = idata.secpol;
     let rawrequest = RawRequest {
@@ -77,9 +78,10 @@ fn early_block(idata: IData, block: ContentFilterBlock) -> (Decision, Tags, Requ
         &mut logs,
         &secpolicy.content_filter_profile.decoding,
         &secpolicy.content_filter_profile.content_type,
+        0,
         &rawrequest,
     );
-    (Decision::Action(block.to_action()), Tags::default(), reqinfo)
+    (Decision::Action(action), Tags::default(), reqinfo)
 }
 
 /// incrementally add headers, can exit early if there are too many headers, or they are too large
@@ -87,20 +89,34 @@ fn early_block(idata: IData, block: ContentFilterBlock) -> (Decision, Tags, Requ
 /// other properties are not checked at this point (restrict for example), this early check purely exists as an anti DOS measure
 pub fn add_header(idata: IData, new_headers: HashMap<String, String>) -> Result<IData, (Decision, Tags, RequestInfo)> {
     let mut dt = idata;
-    let secpol = &dt.secpol;
+    let secpol = dt.secpol;
     if secpol.content_filter_active {
         let hdrs = &secpol.content_filter_profile.sections.headers;
         if dt.headers.len() + new_headers.len() > hdrs.max_count {
-            return Err(early_block(dt, ContentFilterBlock::TooManyEntries(SectionIdx::Headers)));
+            return Err(early_block(
+                dt,
+                ContentFilterBlock::TooManyEntries(SectionIdx::Headers).to_action(),
+            ));
         }
         for (k, v) in new_headers {
+            let kl = k.to_lowercase();
+            if kl == "content-length" {
+                if let Ok(content_length) = v.parse::<usize>() {
+                    if content_length > secpol.content_filter_profile.max_body_size {
+                        return Err(early_block(
+                            dt,
+                            body_too_large(secpol.content_filter_profile.max_body_size, content_length),
+                        ));
+                    }
+                }
+            }
             if v.len() > hdrs.max_length {
                 return Err(early_block(
                     dt,
-                    ContentFilterBlock::EntryTooLarge(SectionIdx::Headers, k),
+                    ContentFilterBlock::EntryTooLarge(SectionIdx::Headers, kl).to_action(),
                 ));
             }
-            dt.headers.insert(k, v);
+            dt.headers.insert(kl, v);
         }
     } else {
         dt.headers.extend(new_headers);
@@ -111,6 +127,16 @@ pub fn add_header(idata: IData, new_headers: HashMap<String, String>) -> Result<
 /// TODO, incremental filtering of body based on the security policy (mainly body length)
 pub fn add_body(idata: IData, new_body: Vec<u8>) -> Result<IData, (Decision, Tags, RequestInfo)> {
     let mut dt = idata;
+    let cur_body_size = dt.body.as_ref().map(|v| v.len()).unwrap_or(0);
+    let new_size = cur_body_size + new_body.len();
+    let secpol = dt.secpol;
+    if new_size > secpol.content_filter_profile.max_body_size {
+        return Err(early_block(
+            dt,
+            body_too_large(secpol.content_filter_profile.max_body_size, new_size),
+        ));
+    }
+
     match dt.body.as_mut() {
         None => dt.body = Some(new_body),
         Some(b) => b.extend(new_body),
@@ -136,6 +162,7 @@ pub async fn finalize<'t, GH: Grasshopper>(
         &mut logs,
         &secpolicy.content_filter_profile.decoding,
         &secpolicy.content_filter_profile.content_type,
+        secpolicy.content_filter_profile.max_body_depth,
         &rawrequest,
     );
 

--- a/curiefense/curieproxy/rust/curiefense/src/tagging.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/tagging.rs
@@ -183,6 +183,7 @@ mod tests {
             &mut logs,
             &[],
             &[],
+            500,
             &RawRequest {
                 ipstr: "52.78.12.56".to_string(),
                 headers,


### PR DESCRIPTION
This patch adds new configuration optional options in content filter profiles:

 * `max_body_size`: governs maximum body size. In this patch, it is not
   as powerful as it could be as the body is already in memory when a
   decision is reached. However, with #817, it will work much earlier,
   possibly as soon as the `Content-Length` header is seen.
 * `max_body_depth`: governs the maximum depth of elements in the body.
   This is useful for nested document types, such as XML, JSON and
   GraphQL. If set to 0, body inspection is skipped.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>