### PR TITLE
External processing patch

### DIFF
--- a/curiefense/curieproxy/lua/accesslog.lua
+++ b/curiefense/curieproxy/lua/accesslog.lua
@@ -9,12 +9,12 @@ local LOG_KEY = "request.info"
 local function get_log_table(request_map)
   -- handle is userData which is not serializable
   local entries = {
-    ["geo"]     = "geo",
-    ["headers"] = "headers",
-    ["cookies"] = "cookies",
-    ["args"]    = "arguments",
-    ["attrs"]   = "attributes",
-    ["tags"]    = "tags"
+    ["geo"]        = "geo",
+    ["headers"]    = "headers",
+    ["cookies"]    = "cookies",
+    ["args"]       = "arguments",
+    ["attributes"] = "attributes",
+    ["tags"]       = "tags"
   }
 
   local log_table = {}

--- a/curiefense/curieproxy/rust/Cargo.toml
+++ b/curiefense/curieproxy/rust/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "curiefense",
     "curiefense-lua",
     "curiefense-ffi",
+    "curiefense-externalprocessing",
 ]
 
 [profile.bench]

--- a/curiefense/curieproxy/rust/NOTES.md
+++ b/curiefense/curieproxy/rust/NOTES.md
@@ -259,7 +259,7 @@ Example, when actions needs to be taken:
          "c" : "cmd.exe",
          "foo" : "bar"
       },
-      "attrs" : {
+      "attributes" : {
          "ip" : "172.19.0.1",
          "ipnum" : "2886926337",
          "path" : "/test/",

--- a/curiefense/curieproxy/rust/curiefense-externalprocessing/Cargo.toml
+++ b/curiefense/curieproxy/rust/curiefense-externalprocessing/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "curiefense-externalprocessing"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]] # Bin to run the HelloWorld gRPC server
+name = "cf-externalprocessing"
+path = "src/server.rs"
+
+[dependencies]
+tonic = "0.7"
+prost = "0.10"
+prost-types = "0.10"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio-stream = "0.1"
+curiefense = { path = "../curiefense" }
+structopt = "0.3"
+log = "0.4"
+syslog = "6.0"
+simplelog = "0.12"
+lazy_static = "*"
+elasticsearch = "7.14.0-alpha.1"
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde", "clock"] }

--- a/curiefense/curieproxy/rust/curiefense-externalprocessing/src/ext_proc.rs
+++ b/curiefense/curieproxy/rust/curiefense-externalprocessing/src/ext_proc.rs
@@ -1,0 +1,619 @@
+/// Nested message and enum types in `ProcessingMode`.
+pub mod processing_mode {
+    /// Control how headers and trailers are handled
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum HeaderSendMode {
+        /// The default HeaderSendMode depends on which part of the message is being
+        /// processed. By default, request and response headers are sent,
+        /// while trailers are skipped.
+        Default = 0,
+        /// Send the header or trailer.
+        Send = 1,
+        /// Do not send the header or trailer.
+        Skip = 2,
+    }
+    /// Control how the request and response bodies are handled
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum BodySendMode {
+        /// Do not send the body at all. This is the default.
+        None = 0,
+        /// Stream the body to the server in pieces as they arrive at the
+        /// proxy.
+        Streamed = 1,
+        /// Buffer the message body in memory and send the entire body at once.
+        /// If the body exceeds the configured buffer limit, then the
+        /// downstream system will receive an error.
+        Buffered = 2,
+        /// Buffer the message body in memory and send the entire body in one
+        /// chunk. If the body exceeds the configured buffer limit, then the body contents
+        /// up to the buffer limit will be sent.
+        BufferedPartial = 3,
+    }
+}
+/// [#next-free-field: 7]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProcessingMode {
+    /// How to handle the request header. Default is "SEND".
+    #[prost(enumeration = "processing_mode::HeaderSendMode", tag = "1")]
+    pub request_header_mode: i32,
+    /// How to handle the response header. Default is "SEND".
+    #[prost(enumeration = "processing_mode::HeaderSendMode", tag = "2")]
+    pub response_header_mode: i32,
+    /// How to handle the request body. Default is "NONE".
+    #[prost(enumeration = "processing_mode::BodySendMode", tag = "3")]
+    pub request_body_mode: i32,
+    /// How do handle the response body. Default is "NONE".
+    #[prost(enumeration = "processing_mode::BodySendMode", tag = "4")]
+    pub response_body_mode: i32,
+    /// How to handle the request trailers. Default is "SKIP".
+    #[prost(enumeration = "processing_mode::HeaderSendMode", tag = "5")]
+    pub request_trailer_mode: i32,
+    /// How to handle the response trailers. Default is "SKIP".
+    #[prost(enumeration = "processing_mode::HeaderSendMode", tag = "6")]
+    pub response_trailer_mode: i32,
+}
+
+/// This represents the different types of messages that Envoy can send
+/// to an external processing server.
+/// [#next-free-field: 8]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProcessingRequest {
+    /// Specify whether the filter that sent this request is running in synchronous
+    /// or asynchronous mode. The choice of synchronous or asynchronous mode
+    /// can be set in the filter configuration, and defaults to false.
+    ///
+    /// * A value of "false" indicates that the server must respond
+    ///   to this message by either sending back a matching ProcessingResponse message,
+    ///   or by closing the stream.
+    /// * A value of "true" indicates that the server must not respond to this
+    ///   message, although it may still close the stream to indicate that no more messages
+    ///   are needed.
+    ///
+    #[prost(bool, tag = "1")]
+    pub async_mode: bool,
+    /// Each request message will include one of the following sub-messages. Which
+    /// ones are set for a particular HTTP request/response depend on the
+    /// processing mode.
+    #[prost(oneof = "processing_request::Request", tags = "2, 3, 4, 5, 6, 7")]
+    pub request: ::core::option::Option<processing_request::Request>,
+}
+/// Nested message and enum types in `ProcessingRequest`.
+pub mod processing_request {
+    /// Each request message will include one of the following sub-messages. Which
+    /// ones are set for a particular HTTP request/response depend on the
+    /// processing mode.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Request {
+        /// Information about the HTTP request headers, as well as peer info and additional
+        /// properties. Unless "async_mode" is true, the server must send back a
+        /// HeaderResponse message, an ImmediateResponse message, or close the stream.
+        #[prost(message, tag = "2")]
+        RequestHeaders(super::HttpHeaders),
+        /// Information about the HTTP response headers, as well as peer info and additional
+        /// properties. Unless "async_mode" is true, the server must send back a
+        /// HeaderResponse message or close the stream.
+        #[prost(message, tag = "3")]
+        ResponseHeaders(super::HttpHeaders),
+        /// A chunk of the HTTP request body. Unless "async_mode" is true, the server must send back
+        /// a BodyResponse message, an ImmediateResponse message, or close the stream.
+        #[prost(message, tag = "4")]
+        RequestBody(super::HttpBody),
+        /// A chunk of the HTTP request body. Unless "async_mode" is true, the server must send back
+        /// a BodyResponse message or close the stream.
+        #[prost(message, tag = "5")]
+        ResponseBody(super::HttpBody),
+        /// The HTTP trailers for the request path. Unless "async_mode" is true, the server
+        /// must send back a TrailerResponse message or close the stream.
+        ///
+        /// This message is only sent if the trailers processing mode is set to "SEND".
+        /// If there are no trailers on the original downstream request, then this message
+        /// will only be sent (with empty trailers waiting to be populated) if the
+        /// processing mode is set before the request headers are sent, such as
+        /// in the filter configuration.
+        #[prost(message, tag = "6")]
+        RequestTrailers(super::HttpTrailers),
+        /// The HTTP trailers for the response path. Unless "async_mode" is true, the server
+        /// must send back a TrailerResponse message or close the stream.
+        ///
+        /// This message is only sent if the trailers processing mode is set to "SEND".
+        /// If there are no trailers on the original downstream request, then this message
+        /// will only be sent (with empty trailers waiting to be populated) if the
+        /// processing mode is set before the request headers are sent, such as
+        /// in the filter configuration.
+        #[prost(message, tag = "7")]
+        ResponseTrailers(super::HttpTrailers),
+    }
+}
+/// For every ProcessingRequest received by the server with the "async_mode" field
+/// set to false, the server must send back exactly one ProcessingResponse message.
+/// [#next-free-field: 10]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProcessingResponse {
+    /// \[#not-implemented-hide:\]
+    /// Optional metadata that will be emitted as dynamic metadata to be consumed by the next
+    /// filter. This metadata will be placed in the namespace "envoy.filters.http.ext_proc".
+    #[prost(message, optional, tag = "8")]
+    pub dynamic_metadata: ::core::option::Option<::prost_types::Struct>,
+    /// Override how parts of the HTTP request and response are processed
+    /// for the duration of this particular request/response only. Servers
+    /// may use this to intelligently control how requests are processed
+    /// based on the headers and other metadata that they see.
+    #[prost(message, optional, tag = "9")]
+    pub mode_override: ::core::option::Option<ProcessingMode>,
+    #[prost(oneof = "processing_response::Response", tags = "1, 2, 3, 4, 5, 6, 7")]
+    pub response: ::core::option::Option<processing_response::Response>,
+}
+/// Nested message and enum types in `ProcessingResponse`.
+pub mod processing_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Response {
+        /// The server must send back this message in response to a message with the
+        /// "request_headers" field set.
+        #[prost(message, tag = "1")]
+        RequestHeaders(super::HeadersResponse),
+        /// The server must send back this message in response to a message with the
+        /// "response_headers" field set.
+        #[prost(message, tag = "2")]
+        ResponseHeaders(super::HeadersResponse),
+        /// The server must send back this message in response to a message with
+        /// the "request_body" field set.
+        #[prost(message, tag = "3")]
+        RequestBody(super::BodyResponse),
+        /// The server must send back this message in response to a message with
+        /// the "response_body" field set.
+        #[prost(message, tag = "4")]
+        ResponseBody(super::BodyResponse),
+        /// The server must send back this message in response to a message with
+        /// the "request_trailers" field set.
+        #[prost(message, tag = "5")]
+        RequestTrailers(super::TrailersResponse),
+        /// The server must send back this message in response to a message with
+        /// the "response_trailers" field set.
+        #[prost(message, tag = "6")]
+        ResponseTrailers(super::TrailersResponse),
+        /// If specified, attempt to create a locally generated response, send it
+        /// downstream, and stop processing additional filters and ignore any
+        /// additional messages received from the remote server for this request or
+        /// response. If a response has already started -- for example, if this
+        /// message is sent response to a "response_body" message -- then
+        /// this will either ship the reply directly to the downstream codec,
+        /// or reset the stream.
+        #[prost(message, tag = "7")]
+        ImmediateResponse(super::ImmediateResponse),
+    }
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HeaderValue {
+    /// Header name.
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+    /// Header value.
+    ///
+    /// The same :ref:`format specifier <config_access_log_format>` as used for
+    /// :ref:`HTTP access logging <config_access_log>` applies here, however
+    /// unknown header values are replaced with the empty string instead of `-`.
+    #[prost(string, tag = "2")]
+    pub value: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HeaderMap {
+    #[prost(message, repeated, tag = "1")]
+    pub headers: ::prost::alloc::vec::Vec<HeaderValue>,
+}
+
+// The following are messages that are sent to the server.
+
+/// This message is sent to the external server when the HTTP request and responses
+/// are first received.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HttpHeaders {
+    /// The HTTP request headers. All header keys will be
+    /// lower-cased, because HTTP header keys are case-insensitive.
+    #[prost(message, optional, tag = "1")]
+    pub headers: ::core::option::Option<HeaderMap>,
+    /// \[#not-implemented-hide:\]
+    /// The values of properties selected by the "request_attributes"
+    /// or "response_attributes" list in the configuration. Each entry
+    /// in the list is populated
+    /// from the standard :ref:`attributes <arch_overview_attributes>`
+    /// supported across Envoy.
+    #[prost(map = "string, message", tag = "2")]
+    pub attributes: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Struct>,
+    /// If true, then there is no message body associated with this
+    /// request or response.
+    #[prost(bool, tag = "3")]
+    pub end_of_stream: bool,
+}
+/// This message contains the message body that Envoy sends to the external server.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HttpBody {
+    #[prost(bytes = "vec", tag = "1")]
+    pub body: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bool, tag = "2")]
+    pub end_of_stream: bool,
+}
+/// This message contains the trailers.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HttpTrailers {
+    #[prost(message, optional, tag = "1")]
+    pub trailers: ::core::option::Option<HeaderMap>,
+}
+// The following are messages that may be sent back by the server.
+
+/// This message must be sent in response to an HttpHeaders message.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HeadersResponse {
+    #[prost(message, optional, tag = "1")]
+    pub response: ::core::option::Option<CommonResponse>,
+}
+/// This message must be sent in response to an HttpTrailers message.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TrailersResponse {
+    /// Instructions on how to manipulate the trailers
+    #[prost(message, optional, tag = "1")]
+    pub header_mutation: ::core::option::Option<HeaderMutation>,
+}
+/// This message must be sent in response to an HttpBody message.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BodyResponse {
+    #[prost(message, optional, tag = "1")]
+    pub response: ::core::option::Option<CommonResponse>,
+}
+/// This message contains common fields between header and body responses.
+/// [#next-free-field: 6]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommonResponse {
+    /// If set, provide additional direction on how the Envoy proxy should
+    /// handle the rest of the HTTP filter chain.
+    #[prost(enumeration = "common_response::ResponseStatus", tag = "1")]
+    pub status: i32,
+    /// Instructions on how to manipulate the headers. When responding to an
+    /// HttpBody request, header mutations will only take effect if
+    /// the current processing mode for the body is BUFFERED.
+    #[prost(message, optional, tag = "2")]
+    pub header_mutation: ::core::option::Option<HeaderMutation>,
+    /// Replace the body of the last message sent to the remote server on this
+    /// stream. If responding to an HttpBody request, simply replace or clear
+    /// the body chunk that was sent with that request. Body mutations only take
+    /// effect in response to "body" messages and are ignored otherwise.
+    #[prost(message, optional, tag = "3")]
+    pub body_mutation: ::core::option::Option<BodyMutation>,
+    /// \[#not-implemented-hide:\]
+    /// Add new trailers to the message. This may be used when responding to either a
+    /// HttpHeaders or HttpBody message, but only if this message is returned
+    /// along with the CONTINUE_AND_REPLACE status.
+    #[prost(message, optional, tag = "4")]
+    pub trailers: ::core::option::Option<HeaderMap>,
+    /// Clear the route cache for the current request.
+    /// This is necessary if the remote server
+    /// modified headers that are used to calculate the route.
+    #[prost(bool, tag = "5")]
+    pub clear_route_cache: bool,
+}
+/// Nested message and enum types in `CommonResponse`.
+pub mod common_response {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum ResponseStatus {
+        /// Apply the mutation instructions in this message to the
+        /// request or response, and then continue processing the filter
+        /// stream as normal. This is the default.
+        Continue = 0,
+        /// Apply the specified header mutation, replace the body with the body
+        /// specified in the body mutation (if present), and do not send any
+        /// further messages for this request or response even if the processing
+        /// mode is configured to do so.
+        ///
+        /// When used in response to a request_headers or response_headers message,
+        /// this status makes it possible to either completely replace the body
+        /// while discarding the original body, or to add a body to a message that
+        /// formerly did not have one.
+        ///
+        /// In other words, this response makes it possible to turn an HTTP GET
+        /// into a POST, PUT, or PATCH.
+        ContinueAndReplace = 1,
+    }
+}
+/// HTTP status.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HttpStatus {
+    /// Supplies HTTP response code.
+    #[prost(enumeration = "StatusCode", tag = "1")]
+    pub code: i32,
+}
+/// This message causes the filter to attempt to create a locally
+/// generated response, send it  downstream, stop processing
+/// additional filters, and ignore any additional messages received
+/// from the remote server for this request or response. If a response
+/// has already started, then  this will either ship the reply directly
+/// to the downstream codec, or reset the stream.
+/// [#next-free-field: 6]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ImmediateResponse {
+    /// The response code to return
+    #[prost(message, optional, tag = "1")]
+    pub status: ::core::option::Option<HttpStatus>,
+    /// Apply changes to the default headers, which will include content-type.
+    #[prost(message, optional, tag = "2")]
+    pub headers: ::core::option::Option<HeaderMutation>,
+    /// The message body to return with the response which is sent using the
+    /// text/plain content type, or encoded in the grpc-message header.
+    #[prost(string, tag = "3")]
+    pub body: ::prost::alloc::string::String,
+    /// If set, then include a gRPC status trailer.
+    #[prost(message, optional, tag = "4")]
+    pub grpc_status: ::core::option::Option<GrpcStatus>,
+    /// A string detailing why this local reply was sent, which may be included
+    /// in log and debug output (e.g. this populates the %RESPONSE_CODE_DETAILS%
+    /// command operator field for use in access logging).
+    #[prost(string, tag = "5")]
+    pub details: ::prost::alloc::string::String,
+}
+/// This message specifies a gRPC status for an ImmediateResponse message.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GrpcStatus {
+    /// The actual gRPC status
+    #[prost(uint32, tag = "1")]
+    pub status: u32,
+}
+/// Nested message and enum types in `HeaderValueOption`.
+pub mod header_value_option {
+    /// Describes the supported actions types for header append action.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum HeaderAppendAction {
+        /// This action will append the specified value to the existing values if the header
+        /// already exists. If the header doesn't exist then this will add the header with
+        /// specified key and value.
+        AppendIfExistsOrAdd = 0,
+        /// This action will add the header if it doesn't already exist. If the header
+        /// already exists then this will be a no-op.
+        AddIfAbsent = 1,
+        /// This action will overwrite the specified value by discarding any existing values if
+        /// the header already exists. If the header doesn't exist then this will add the header
+        /// with specified key and value.
+        OverwriteIfExistsOrAdd = 2,
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HeaderValueOption {
+    /// Header name/value pair that this option applies to.
+    #[prost(message, optional, tag = "1")]
+    pub header: ::core::option::Option<HeaderValue>,
+    /// Should the value be appended? If true (default), the value is appended to
+    /// existing values. Otherwise it replaces any existing values.
+    #[prost(message, optional, tag = "2")]
+    pub append: ::core::option::Option<bool>,
+    /// \[#not-implemented-hide:\] Describes the action taken to append/overwrite the given value for an existing header
+    /// or to only add this header if it's absent. Value defaults to :ref:`APPEND_IF_EXISTS_OR_ADD<envoy_v3_api_enum_value_config.core.v3.HeaderValueOption.HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD>`.
+    #[prost(enumeration = "header_value_option::HeaderAppendAction", tag = "3")]
+    pub append_action: i32,
+}
+/// Change HTTP headers or trailers by appending, replacing, or removing
+/// headers.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HeaderMutation {
+    /// Add or replace HTTP headers. Attempts to set the value of
+    /// any "x-envoy" header, and attempts to set the ":method",
+    /// ":authority", ":scheme", or "host" headers will be ignored.
+    #[prost(message, repeated, tag = "1")]
+    pub set_headers: ::prost::alloc::vec::Vec<HeaderValueOption>,
+    /// Remove these HTTP headers. Attempts to remove system headers --
+    /// any header starting with ":", plus "host" -- will be ignored.
+    #[prost(string, repeated, tag = "2")]
+    pub remove_headers: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Replace the entire message body chunk received in the corresponding
+/// HttpBody message with this new body, or clear the body.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BodyMutation {
+    #[prost(oneof = "body_mutation::Mutation", tags = "1, 2")]
+    pub mutation: ::core::option::Option<body_mutation::Mutation>,
+}
+/// Nested message and enum types in `BodyMutation`.
+pub mod body_mutation {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Mutation {
+        /// The entire body to replace
+        #[prost(bytes, tag = "1")]
+        Body(::prost::alloc::vec::Vec<u8>),
+        /// Clear the corresponding body chunk
+        #[prost(bool, tag = "2")]
+        ClearBody(bool),
+    }
+}
+/// Generated server implementations.
+pub mod external_processor_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    ///Generated trait containing gRPC methods that should be implemented for use with ExternalProcessorServer.
+    #[async_trait]
+    pub trait ExternalProcessor: Send + Sync + 'static {
+        ///Server streaming response type for the Process method.
+        type ProcessStream: futures_core::Stream<Item = Result<super::ProcessingResponse, tonic::Status>>
+            + Send
+            + 'static;
+        /// This begins the bidirectional stream that Envoy will use to
+        /// give the server control over what the filter does. The actual
+        /// protocol is described by the ProcessingRequest and ProcessingResponse
+        /// messages below.
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<super::ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct ExternalProcessorServer<T: ExternalProcessor> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: ExternalProcessor> ExternalProcessorServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ExternalProcessorServer<T>
+    where
+        T: ExternalProcessor,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/envoy.service.ext_proc.v3.ExternalProcessor/Process" => {
+                    #[allow(non_camel_case_types)]
+                    struct ProcessSvc<T: ExternalProcessor>(pub Arc<T>);
+                    impl<T: ExternalProcessor> tonic::server::StreamingService<super::ProcessingRequest> for ProcessSvc<T> {
+                        type Response = super::ProcessingResponse;
+                        type ResponseStream = T::ProcessStream;
+                        type Future = BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<tonic::Streaming<super::ProcessingRequest>>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).process(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ProcessSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(accept_compression_encodings, send_compression_encodings);
+                        let res = grpc.streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: ExternalProcessor> Clone for ExternalProcessorServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: ExternalProcessor> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: ExternalProcessor> tonic::transport::NamedService for ExternalProcessorServer<T> {
+        const NAME: &'static str = "envoy.service.ext_proc.v3.ExternalProcessor";
+    }
+}
+
+/// HTTP response codes supported in Envoy.
+/// For more details: <https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml>
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum StatusCode {
+    /// Empty - This code not part of the HTTP status code specification, but it is needed for proto
+    /// `enum` type.
+    Empty = 0,
+    Continue = 100,
+    Ok = 200,
+    Created = 201,
+    Accepted = 202,
+    NonAuthoritativeInformation = 203,
+    NoContent = 204,
+    ResetContent = 205,
+    PartialContent = 206,
+    MultiStatus = 207,
+    AlreadyReported = 208,
+    ImUsed = 226,
+    MultipleChoices = 300,
+    MovedPermanently = 301,
+    Found = 302,
+    SeeOther = 303,
+    NotModified = 304,
+    UseProxy = 305,
+    TemporaryRedirect = 307,
+    PermanentRedirect = 308,
+    BadRequest = 400,
+    Unauthorized = 401,
+    PaymentRequired = 402,
+    Forbidden = 403,
+    NotFound = 404,
+    MethodNotAllowed = 405,
+    NotAcceptable = 406,
+    ProxyAuthenticationRequired = 407,
+    RequestTimeout = 408,
+    Conflict = 409,
+    Gone = 410,
+    LengthRequired = 411,
+    PreconditionFailed = 412,
+    PayloadTooLarge = 413,
+    UriTooLong = 414,
+    UnsupportedMediaType = 415,
+    RangeNotSatisfiable = 416,
+    ExpectationFailed = 417,
+    MisdirectedRequest = 421,
+    UnprocessableEntity = 422,
+    Locked = 423,
+    FailedDependency = 424,
+    UpgradeRequired = 426,
+    PreconditionRequired = 428,
+    TooManyRequests = 429,
+    RequestHeaderFieldsTooLarge = 431,
+    InternalServerError = 500,
+    NotImplemented = 501,
+    BadGateway = 502,
+    ServiceUnavailable = 503,
+    GatewayTimeout = 504,
+    HttpVersionNotSupported = 505,
+    VariantAlsoNegotiates = 506,
+    InsufficientStorage = 507,
+    LoopDetected = 508,
+    NotExtended = 510,
+    NetworkAuthenticationRequired = 511,
+}

--- a/curiefense/curieproxy/rust/curiefense-externalprocessing/src/server.rs
+++ b/curiefense/curieproxy/rust/curiefense-externalprocessing/src/server.rs
@@ -1,0 +1,461 @@
+use curiefense::{
+    config::{
+        flow::{FlowElement, SequenceKey},
+        globalfilter::GlobalFilterSection,
+        with_config,
+    },
+    grasshopper::DummyGrasshopper,
+    incremental::{add_body, add_header, finalize, inspect_init, IData},
+    interface::{jsonlog, Decision, Tags},
+    logs::{LogLevel, Logs},
+    utils::{RequestInfo, RequestMeta},
+};
+use elasticsearch::{http::transport::Transport, Elasticsearch};
+use lazy_static::lazy_static;
+use log::{debug, error, info, warn, LevelFilter};
+use serde_json::Value;
+use std::{collections::HashMap, sync::RwLock};
+use structopt::StructOpt;
+use syslog::{Facility, Formatter3164, LoggerBackend};
+use tokio::{
+    spawn,
+    sync::mpsc::{self, error::SendError, Receiver, Sender},
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{transport::Server, Request, Status};
+
+mod ext_proc;
+
+use ext_proc::{
+    external_processor_server::{ExternalProcessor, ExternalProcessorServer},
+    processing_response, BodyResponse, HeaderMutation, HeaderValue, HeaderValueOption, HeadersResponse, HttpStatus,
+    ImmediateResponse, ProcessingRequest, ProcessingResponse,
+};
+
+lazy_static! {
+    static ref LOGGER: RwLock<Option<syslog::Logger<LoggerBackend, Formatter3164>>> = RwLock::new(None);
+}
+
+#[derive(Clone)]
+pub struct MyEP {
+    handle_replies: bool,
+    reqchannel: Sender<CfgRequest>,
+    logsender: Option<Sender<Value>>,
+}
+
+type CfgRequest = (
+    RequestMeta,
+    Sender<Option<Result<(IData, Vec<GlobalFilterSection>, HashMap<SequenceKey, Vec<FlowElement>>), String>>>,
+);
+
+/// this function loops and waits for configuration queries
+/// it is done so that configuration requests are serialized
+///
+/// this potentially reduces paralellism, but also avoids the problem of queued configuration reloads
+async fn configloop(rx: Receiver<CfgRequest>, configpath: &str, loglevel: LogLevel, trustedhops: u32) {
+    let mut mrx = rx;
+    loop {
+        let (meta, sender) = match mrx.recv().await {
+            None => {
+                error!("should not happen, channel closed?");
+                break;
+            }
+            Some(x) => x,
+        };
+
+        let mut logs = Logs::new(loglevel);
+        let midata = with_config(configpath, &mut logs, |_, cfg| {
+            inspect_init(cfg, loglevel, meta, trustedhops).map(|o| {
+                // we have to clone all this data here :(
+                // that would not be necessary if we could avoid the autoreloading feature, but had a system for reloading the server when the configuration changes
+                let gf = cfg.globalfilters.clone();
+                let fl = cfg.flows.clone();
+                (o, gf, fl)
+            })
+        });
+        show_logs(logs);
+        match sender.send(midata).await {
+            Ok(()) => (),
+            Err(rr) => {
+                error!("Could not send midata {}", rr);
+                break;
+            }
+        }
+    }
+}
+
+async fn logloop(rx: Receiver<Value>, client: Elasticsearch) {
+    let mut mrx = rx;
+    loop {
+        match mrx.recv().await {
+            None => {
+                error!("should not happen, logging channel closed?");
+                break;
+            }
+            Some(mut v) => {
+                let now = chrono::Utc::now();
+                if let Some(hm) = v.as_object_mut() {
+                    // might be slow!
+                    hm.insert("@timestamp".to_string(), serde_json::to_value(&now).unwrap());
+                }
+                let idx = now.format("curieaccesslog-%Y.%m.%d-000001").to_string();
+                match client
+                    .index(elasticsearch::IndexParts::Index(&idx))
+                    .body(v)
+                    .send()
+                    .await
+                {
+                    Err(rr) => error!("When logging to ES: {}", rr),
+                    Ok(response) => {
+                        if !response.status_code().is_success() {
+                            error!("When logging to ES: {:?}", response);
+                        } else {
+                            info!("{:?}", response);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl MyEP {
+    fn new(reqchannel: Sender<CfgRequest>, handle_replies: bool, logsender: Option<Sender<Value>>) -> Self {
+        MyEP {
+            handle_replies,
+            reqchannel,
+            logsender,
+        }
+    }
+
+    // the main content handling loop
+    async fn handle(
+        self,
+        tx: &mut Sender<Result<ProcessingResponse, Status>>,
+        msg: &mut tonic::Streaming<ProcessingRequest>,
+    ) -> Result<(), String> {
+        // currently, the first request is for headers, and then we might get body parts
+        async fn next_message(m: &mut tonic::Streaming<ProcessingRequest>) -> Result<ProcessingRequest, String> {
+            m.message()
+                .await
+                .map_err(|s| s.to_string())?
+                .ok_or_else(|| "No processing request".to_string())
+        }
+
+        let mut meta: HashMap<String, String> = HashMap::new();
+        let mut mheaders: HashMap<String, String> = HashMap::new();
+        let headers_only = match next_message(msg).await?.request {
+            Some(ext_proc::processing_request::Request::RequestHeaders(headers)) => {
+                if let Some(hdrmap) = headers.headers {
+                    for h in hdrmap.headers {
+                        match h.key.strip_prefix(':') {
+                            None => {
+                                mheaders.insert(h.key, h.value);
+                            }
+                            Some(m) => {
+                                meta.insert(m.to_string(), h.value);
+                            }
+                        }
+                    }
+                }
+                headers.end_of_stream
+            }
+            something_else => return Err(format!("Expected a RequestHeaders, but got {:?}", something_else)),
+        };
+
+        let meta = match RequestMeta::from_map(meta) {
+            Ok(m) => m,
+            Err(rr) => {
+                error!("Could not get request meta: {}", rr);
+                return Ok(());
+            }
+        };
+
+        // get configuration data from the dedicated task
+        let (rtx, mut rrx) = mpsc::channel(1);
+        self.reqchannel.send((meta, rtx)).await.unwrap();
+        let midata = rrx.recv().await;
+
+        let (idata, globalfilters, flows) = midata.unwrap().unwrap().unwrap();
+
+        let mut idata = match add_header(idata, mheaders) {
+            Ok(i) => i,
+            Err((logs, dec)) => {
+                self.send_action(ProcessingStage::Headers, tx, dec, logs).await;
+                return Ok(());
+            }
+        };
+
+        if !headers_only {
+            stage_pass(ProcessingStage::Headers, tx).await;
+            loop {
+                match next_message(msg).await?.request {
+                    Some(ext_proc::processing_request::Request::RequestBody(bdy)) => {
+                        idata = match add_body(idata, bdy.body) {
+                            Ok(i) => i,
+                            Err((logs, dec)) => {
+                                self.send_action(ProcessingStage::Body, tx, dec, logs).await;
+                                return Ok(());
+                            }
+                        };
+                        if bdy.end_of_stream {
+                            break;
+                        }
+                    }
+                    something_else => return Err(format!("Expected a RequestBody, but got {:?}", something_else)),
+                }
+            }
+        }
+
+        let (dec, logs) = finalize(idata, Some(DummyGrasshopper {}), &globalfilters, &flows, None).await;
+        self.send_action(
+            if headers_only {
+                ProcessingStage::Headers
+            } else {
+                ProcessingStage::Body
+            },
+            tx,
+            dec,
+            logs,
+        )
+        .await;
+
+        if self.handle_replies {
+            let code: Option<u32> = match next_message(msg).await?.request {
+                Some(ext_proc::processing_request::Request::ResponseHeaders(hdrs)) => hdrs
+                    .headers
+                    .iter()
+                    .flat_map(|hm| hm.headers.iter())
+                    .filter_map(|hv| {
+                        if hv.key == ":status" {
+                            hv.value.parse().ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .next(),
+
+                something_else => {
+                    error!("Expected a ResponseHeaders, but got {:?}", something_else);
+                    None
+                }
+            };
+            stage_pass(ProcessingStage::RHeaders, tx).await;
+            debug!("* return code: {:?}", code);
+        }
+        Ok(())
+    }
+
+    async fn send_action(
+        &self,
+        stage: ProcessingStage,
+        tx: &mut Sender<Result<ProcessingResponse, Status>>,
+        action: (Decision, Tags, RequestInfo),
+        logs: Logs,
+    ) {
+        let (decision, tags, masked_rinfo) = action;
+        match &decision {
+            Decision::Pass => stage_pass(stage, tx).await,
+            Decision::Action(a) => {
+                if a.block_mode {
+                    tx.send(Ok(ProcessingResponse {
+                        response: Some(ext_proc::processing_response::Response::ImmediateResponse(
+                            ImmediateResponse {
+                                status: Some(HttpStatus { code: a.status as i32 }),
+                                details: format!("{}", a.reason),
+                                body: a.content.clone(),
+                                headers: a.headers.clone().map(mutate_headers),
+                                grpc_status: None,
+                            },
+                        )),
+                        ..Default::default()
+                    }))
+                    .await
+                    .unwrap();
+                } else {
+                    stage_pass(stage, tx).await
+                }
+            }
+        }
+
+        let v = jsonlog(&decision, masked_rinfo, tags);
+        for l in logs.to_stringvec() {
+            debug!("{}", l);
+        }
+        info!("CFLOG {}", v);
+        if let Some(tx) = &self.logsender {
+            if let Err(rr) = tx.send(v).await {
+                error!("Could not log: {}", rr);
+            }
+        }
+    }
+}
+
+fn mutate_headers(headers: HashMap<String, String>) -> HeaderMutation {
+    HeaderMutation {
+        set_headers: headers
+            .into_iter()
+            .map(|(key, value)| HeaderValueOption {
+                header: Some(HeaderValue { key, value }),
+                append: None,
+                append_action: 0,
+            })
+            .collect(),
+        remove_headers: Vec::new(),
+    }
+}
+
+async fn send_response(
+    tx: &mut Sender<Result<ProcessingResponse, Status>>,
+    r: processing_response::Response,
+) -> Result<(), SendError<Result<ext_proc::ProcessingResponse, tonic::Status>>> {
+    tx.send(Ok(ProcessingResponse {
+        response: Some(r),
+        ..Default::default()
+    }))
+    .await
+}
+
+#[derive(Clone, Copy)]
+enum ProcessingStage {
+    Headers,
+    Body,
+    RHeaders,
+}
+
+async fn stage_pass(stage: ProcessingStage, tx: &mut Sender<Result<ProcessingResponse, Status>>) {
+    send_response(
+        tx,
+        match stage {
+            ProcessingStage::Headers => {
+                processing_response::Response::RequestHeaders(HeadersResponse { response: None })
+            }
+            ProcessingStage::Body => processing_response::Response::RequestBody(BodyResponse { response: None }),
+            ProcessingStage::RHeaders => {
+                processing_response::Response::ResponseHeaders(ext_proc::HeadersResponse { response: None })
+            }
+        },
+    )
+    .await
+    .unwrap();
+}
+
+fn show_logs(logs: Logs) {
+    let vlogs = logs.to_stringvec();
+    if !vlogs.is_empty() {
+        warn!("CONFIGURATION LOGS:");
+        for l in vlogs {
+            warn!("{}", l);
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl ExternalProcessor for MyEP {
+    type ProcessStream = ReceiverStream<Result<ProcessingResponse, Status>>;
+    async fn process(
+        &self,
+        request: Request<tonic::Streaming<ProcessingRequest>>,
+    ) -> Result<tonic::Response<ReceiverStream<Result<ProcessingResponse, Status>>>, Status> {
+        let (mut tx, rx) = mpsc::channel(4);
+        let mut message = request.into_inner();
+
+        let cep = self.clone();
+
+        spawn(async move {
+            if let Err(msg) = cep.handle(&mut tx, &mut message).await {
+                error!("{}", msg);
+                send_response(
+                    &mut tx,
+                    processing_response::Response::ImmediateResponse(ext_proc::ImmediateResponse {
+                        status: Some(ext_proc::HttpStatus { code: 403 }),
+                        headers: None,
+                        body: String::new(),
+                        grpc_status: None,
+                        details: msg,
+                    }),
+                )
+                .await
+                .unwrap()
+            }
+            message.trailers().await.unwrap();
+        });
+
+        Ok(tonic::Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "cf-externalprocessing",
+    about = "An envoy external processing server for curiefense."
+)]
+
+struct Opt {
+    #[structopt(long, default_value = "0.0.0.0:50051")]
+    listen: String,
+    #[structopt(long)]
+    configpath: String,
+    #[structopt(long, default_value = "info")]
+    loglevel: String,
+    #[structopt(long, default_value = "1")]
+    trustedhops: u32,
+    #[structopt(long)]
+    handle_replies: bool,
+    #[structopt(long)]
+    syslog: bool,
+    #[structopt(long)]
+    elasticsearch: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // note that there is a lot of performance left on the table because of the autoreload system
+    // the reason is that with the asynchronous code, we can't borrow anything from the configuration,
+    // but have to own everything, as there is no guarantee the configuration won't move under our feet.
+    let opt = Opt::from_args();
+    let addr = opt.listen.parse()?;
+    let loglevel = opt.loglevel.parse()?;
+    let level_filter = match &loglevel {
+        LogLevel::Debug => LevelFilter::Debug,
+        _ => LevelFilter::Info,
+    };
+    // initial configuration loading
+    let mut logs = Logs::new(loglevel);
+    with_config(&opt.configpath, &mut logs, |_, _| {});
+    show_logs(logs);
+
+    if opt.syslog {
+        syslog::init_unix(Facility::LOG_USER, level_filter)?;
+    } else {
+        simplelog::TermLogger::init(
+            level_filter,
+            simplelog::Config::default(),
+            simplelog::TerminalMode::Stdout,
+            simplelog::ColorChoice::Auto,
+        )?;
+    };
+
+    let (ctx, crx) = mpsc::channel(4);
+
+    let _ = spawn(async move { configloop(crx, &opt.configpath, loglevel, opt.trustedhops).await });
+
+    let mut logsender: Option<Sender<Value>> = None;
+
+    if let Some(esurl) = opt.elasticsearch {
+        let (logtx, logrx) = mpsc::channel(500);
+        let transport = Transport::single_node(&esurl)?;
+        let client = Elasticsearch::new(transport);
+        logsender = Some(logtx);
+        let _ = spawn(async move { logloop(logrx, client).await });
+    }
+
+    let ep = MyEP::new(ctx, opt.handle_replies, logsender);
+    Server::builder()
+        .accept_http1(true)
+        .add_service(ExternalProcessorServer::new(ep))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/curiefense/curieproxy/rust/curiefense/src/grasshopper.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/grasshopper.rs
@@ -16,16 +16,16 @@ pub struct DummyGrasshopper {}
 // use this when grasshopper can't be used
 impl Grasshopper for DummyGrasshopper {
     fn js_app(&self) -> Option<String> {
-        None
+        Some("dummy_grasshopper_for_testing_only".to_string())
     }
     fn js_bio(&self) -> Option<String> {
-        None
+        Some("dummy_grasshopper_for_testing_only".to_string())
     }
     fn parse_rbzid(&self, _rbzid: &str, _seed: &str) -> Option<bool> {
-        None
+        Some(false)
     }
     fn gen_new_seed(&self, _seed: &str) -> Option<String> {
-        None
+        Some("dummy_grasshopper_for_testing_only".to_string())
     }
     fn verify_workproof(&self, _workproof: &str, _seed: &str) -> Option<String> {
         None

--- a/curiefense/curieproxy/rust/curiefense/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/lib.rs
@@ -17,6 +17,7 @@ pub mod simple_executor;
 pub mod tagging;
 pub mod utils;
 
+use analyze::CfRulesArg;
 use body::body_too_large;
 use config::{with_config, HSDB};
 use contentfilter::content_filter_check;
@@ -173,6 +174,7 @@ pub async fn inspect_generic_request_map_async<GH: Grasshopper>(
         };
 
     tags.extend(ntags);
+
     analyze::analyze(
         logs,
         mgh,
@@ -183,6 +185,7 @@ pub async fn inspect_generic_request_map_async<GH: Grasshopper>(
         is_human,
         globalfilter_dec,
         &flows,
+        CfRulesArg::Global,
     )
     .await
 }

--- a/curiefense/curieproxy/rust/curiefense/src/logs.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/logs.rs
@@ -37,6 +37,20 @@ impl LogLevel {
     }
 }
 
+impl std::str::FromStr for LogLevel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "debug" => Ok(LogLevel::Debug),
+            "info" => Ok(LogLevel::Info),
+            "warning" => Ok(LogLevel::Warning),
+            "error" => Ok(LogLevel::Error),
+            _ => Err(format!("unknown loglevel {}", s)),
+        }
+    }
+}
+
 impl std::fmt::Display for Log {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{} {}µs {}", self.level.short(), self.elapsed_micros, self.message)

--- a/curiefense/curieproxy/rust/curiefense/src/utils.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/utils.rs
@@ -245,6 +245,17 @@ pub struct RequestInfo {
 
 impl RequestInfo {
     pub fn into_json(self, tags: Tags) -> serde_json::Value {
+        let mut v = self.into_json_notags();
+        if let Some(m) = v.as_object_mut() {
+            m.insert(
+                "tags".to_string(),
+                serde_json::to_value(tags).unwrap_or(serde_json::Value::Null),
+            );
+        }
+        v
+    }
+
+    pub fn into_json_notags(self) -> serde_json::Value {
         let ipnum: Option<String> = self.rinfo.geoip.ip.as_ref().map(|i| match i {
             IpAddr::V4(a) => u32::from_be_bytes(a.octets()).to_string(),
             IpAddr::V6(a) => u128::from_be_bytes(a.octets()).to_string(),
@@ -268,8 +279,7 @@ impl RequestInfo {
             "cookies": self.cookies.to_json(),
             "args": self.rinfo.qinfo.args.to_json(),
             "path": self.rinfo.qinfo.path_as_map.to_json(),
-            "attrs": attrs,
-            "tags": tags,
+            "attributes": attrs,
             "geo": geo
         })
     }

--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -29,6 +29,7 @@ if [ -n "$TESTIMG" ]; then
 else
     IMAGES=(confserver curielogger curieproxy-istio curieproxy-envoy \
         curieproxy-nginx curiefense-nginx-ingress curiesync curietasker grafana prometheus \
+        extproc \
         redis uiserver)
 fi
 

--- a/curiefense/images/curiefense-rustbuild/Dockerfile
+++ b/curiefense/images/curiefense-rustbuild/Dockerfile
@@ -15,6 +15,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     cargo test && \
     cargo build --release && \
     cp target/release/libcuriefense_lua.so /root/curiefense.so && \
+    cp target/release/cf-externalprocessing /root/ && \
     rm -rf target /root/.cargo
 
 FROM ubuntu:${UBUNTU_VERSION} as tester
@@ -46,3 +47,4 @@ RUN sh luatests/run.sh
 
 FROM scratch
 COPY --from=builder /root/curiefense.so /root/curiefense.so
+COPY --from=builder /root/cf-externalprocessing /root/cf-externalprocessing

--- a/curiefense/images/curieproxy-envoy/Dockerfile
+++ b/curiefense/images/curieproxy-envoy/Dockerfile
@@ -1,34 +1,11 @@
 ARG RUSTBIN_TAG=latest
-FROM curiefense/curiefense-rustbuild-bionic:${RUSTBIN_TAG} AS rustbin
 FROM curiefense/envoy-cf:15d1607b3035c900ea943ac8e1fed6f15598a46b AS envoy-cf
 FROM envoyproxy/envoy:v1.21.1
-
-RUN apt-get update && \
-    apt-get -qq -y --no-install-recommends install jq luarocks libpcre2-dev libgeoip-dev \
-    python gcc g++ make unzip libhyperscan4 libhyperscan-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN luarocks install lrexlib-pcre2 && \
-    luarocks install lua-cjson && \
-    luarocks install lua-resty-string && \
-    luarocks install luafilesystem && \
-    luarocks install luasocket && \
-    luarocks install redis-lua && \
-    luarocks install compat53 && \
-    luarocks install mmdblua && \
-    luarocks install luaipc && \
-    luarocks install lua-resty-injection
 
 # Overwrite stripped envoy with full symbol
 COPY --from=envoy-cf /envoy /usr/local/bin/envoy
 
 COPY init/start_curiefense.sh /start_curiefense.sh
-COPY curieproxy/lua /lua
-COPY curieproxy/lua/shared-objects/*.so /usr/local/lib/lua/5.1/
-COPY --from=rustbin /root/curiefense.so /usr/local/lib/lua/5.1/
-COPY curieproxy/cf-config /bootstrap-config/config
-COPY curieproxy/envoy.yaml.* /etc/envoy/
-
-RUN mkdir /cf-config && chmod a+rwxt /cf-config
+COPY envoy.yaml.* /etc/envoy/
 
 ENTRYPOINT ["/start_curiefense.sh"]

--- a/curiefense/images/curieproxy-envoy/envoy.yaml.head
+++ b/curiefense/images/curieproxy-envoy/envoy.yaml.head
@@ -1,8 +1,10 @@
-  - name: tls
+static_resources:
+  listeners:
+  - name: main
     address:
       socket_address:
         address: 0.0.0.0
-        port_value: 443
+        port_value: 80
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -35,33 +37,36 @@
                 metadata:
                   filter_metadata:
                     envoy.filters.http.lua:
-                      xff_trusted_hops: 1
+                      xff_trusted_hops: XFF_TRUSTED
           http_filters:
-          - name: envoy.filters.http.lua
+          - name: envoy.filters.http.ext_proc
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local session = require "lua.session_envoy"
-                function envoy_on_request(handle)
-                  session.inspect(handle)
-                end
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+              failure_mode_allow: false
+              async_mode: false              
+              message_timeout: 25s
+              request_attributes:
+              - user
+              response_attributes:
+              - server
+              processing_mode:
+                request_header_mode: "SEND"
+                response_header_mode: "SKIP"
+                request_body_mode: "STREAMED"
+                response_body_mode: "NONE"
+                request_trailer_mode: "SKIP"
+                response_trailer_mode: "SKIP"
+              grpc_service:
+                envoy_grpc:                  
+                  cluster_name: ext_proc_cluster
           - name: envoy.filters.http.router
             typed_config: {}
-      transport_socket:
-        name: envoy.transport_sockets.tls
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-          common_tls_context:
-            tls_certificates:
-              - certificate_chain:
-                  filename: "/run/secrets/curieproxysslcrt"
-                private_key:
-                  filename: "/run/secrets/curieproxysslkey"
-  - name: tlsjuice
+
+  - name: secondary
     address:
       socket_address:
         address: 0.0.0.0
-        port_value: 444
+        port_value: 81
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -94,25 +99,27 @@
                 metadata:
                   filter_metadata:
                     envoy.filters.http.lua:
-                      xff_trusted_hops: 1
+                      xff_trusted_hops: XFF_TRUSTED
           http_filters:
-          - name: envoy.filters.http.lua
+          - name: envoy.filters.http.ext_proc
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local session = require "lua.session_envoy"
-                function envoy_on_request(handle)
-                  session.inspect(handle)
-                end
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+              failure_mode_allow: false
+              message_timeout: 25s
+              async_mode: false              
+              request_attributes:
+              - user
+              response_attributes:
+              - server
+              processing_mode:
+                request_header_mode: "SEND"
+                response_header_mode: "SKIP"
+                request_body_mode: "STREAMED"
+                response_body_mode: "NONE"
+                request_trailer_mode: "SKIP"
+                response_trailer_mode: "SKIP"
+              grpc_service:
+                envoy_grpc:                  
+                  cluster_name: ext_proc_cluster
           - name: envoy.filters.http.router
             typed_config: {}
-      transport_socket:
-        name: envoy.transport_sockets.tls
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-          common_tls_context:
-            tls_certificates:
-              - certificate_chain:
-                  filename: "/run/secrets/curieproxysslcrt"
-                private_key:
-                  filename: "/run/secrets/curieproxysslkey"

--- a/curiefense/images/curieproxy-envoy/envoy.yaml.tail
+++ b/curiefense/images/curieproxy-envoy/envoy.yaml.tail
@@ -45,7 +45,19 @@
               socket_address:
                 address: TARGET_ADDRESS_B
                 port_value: TARGET_PORT_B
-
+  - name: ext_proc_cluster
+    type: strict_dns
+    connect_timeout: 25s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: ext_proc_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: extproc
+                port_value: 50051 
 admin:
   access_log_path: "/dev/null"
   address:

--- a/curiefense/images/curieproxy-envoy/envoy.yaml.tls
+++ b/curiefense/images/curieproxy-envoy/envoy.yaml.tls
@@ -1,10 +1,8 @@
-static_resources:
-  listeners:
-  - name: main
+  - name: tls
     address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 443
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -37,24 +35,45 @@ static_resources:
                 metadata:
                   filter_metadata:
                     envoy.filters.http.lua:
-                      xff_trusted_hops: XFF_TRUSTED
+                      xff_trusted_hops: 1
           http_filters:
-          - name: envoy.filters.http.lua
+          - name: envoy.filters.http.ext_proc
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local session = require "lua.session_envoy"
-                function envoy_on_request(handle)
-                  session.inspect(handle)
-                end
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+              failure_mode_allow: false
+              message_timeout: 25s
+              async_mode: false              
+              request_attributes:
+              - user
+              response_attributes:
+              - server
+              processing_mode:
+                request_header_mode: "SEND"
+                response_header_mode: "SKIP"
+                request_body_mode: "STREAMED"
+                response_body_mode: "NONE"
+                request_trailer_mode: "SKIP"
+                response_trailer_mode: "SKIP"
+              grpc_service:
+                envoy_grpc:                  
+                  cluster_name: ext_proc_cluster
           - name: envoy.filters.http.router
             typed_config: {}
-
-  - name: secondary
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          common_tls_context:
+            tls_certificates:
+              - certificate_chain:
+                  filename: "/run/secrets/curieproxysslcrt"
+                private_key:
+                  filename: "/run/secrets/curieproxysslkey"
+  - name: tlsjuice
     address:
       socket_address:
         address: 0.0.0.0
-        port_value: 81
+        port_value: 444
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -87,15 +106,37 @@ static_resources:
                 metadata:
                   filter_metadata:
                     envoy.filters.http.lua:
-                      xff_trusted_hops: XFF_TRUSTED
+                      xff_trusted_hops: 1
           http_filters:
-          - name: envoy.filters.http.lua
+          - name: envoy.filters.http.ext_proc
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local session = require "lua.session_envoy"
-                function envoy_on_request(handle)
-                  session.inspect(handle)
-                end
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+              failure_mode_allow: false
+              message_timeout: 25s
+              async_mode: false              
+              request_attributes:
+              - user
+              response_attributes:
+              - server
+              processing_mode:
+                request_header_mode: "SEND"
+                response_header_mode: "SKIP"
+                request_body_mode: "STREAMED"
+                response_body_mode: "NONE"
+                request_trailer_mode: "SKIP"
+                response_trailer_mode: "SKIP"
+              grpc_service:
+                envoy_grpc:                  
+                  cluster_name: ext_proc_cluster
           - name: envoy.filters.http.router
             typed_config: {}
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          common_tls_context:
+            tls_certificates:
+              - certificate_chain:
+                  filename: "/run/secrets/curieproxysslcrt"
+                private_key:
+                  filename: "/run/secrets/curieproxysslkey"

--- a/curiefense/images/extproc/Dockerfile
+++ b/curiefense/images/extproc/Dockerfile
@@ -1,0 +1,14 @@
+ARG RUSTBIN_TAG=latest
+FROM curiefense/curiefense-rustbuild-bionic:${RUSTBIN_TAG} as rustbin
+FROM ubuntu:bionic
+
+RUN apt-get update && \
+    apt-get -qq -y --no-install-recommends install jq libhyperscan4 libhyperscan-dev libssl1.1 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=rustbin /root/cf-externalprocessing /usr/local/bin
+
+COPY start_ef.sh /start_ef.sh
+RUN mkdir /cf-config && chmod a+rwxt /cf-config
+
+ENTRYPOINT ["/start_ef.sh"]

--- a/curiefense/images/extproc/start_ef.sh
+++ b/curiefense/images/extproc/start_ef.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+if [ ! -e /cf-config/bootstrap ]
+then
+	cp -va /bootstrap-config /cf-config/bootstrap
+fi
+
+if [ ! -e /cf-config/current ]
+then
+	ln -s bootstrap /cf-config/current
+fi
+
+XFF="${XFF_TRUSTED_HOPS:-1}"
+LOGLEVEL="${EXTPROC_LOG_LEVEL:-debug}"
+
+while true
+do
+	/usr/local/bin/cf-externalprocessing --loglevel "$LOGLEVEL" --configpath /cf-config/current/config --trustedhops "$XFF" --elasticsearch http://elasticsearch:9200/
+	sleep 1
+done

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -1,12 +1,11 @@
 version: "3.7"
 services:
+
   curieproxy:
     container_name: curieproxy
     hostname: curieproxy
     image: "curiefense/curieproxy-envoy:${DOCKER_TAG}"
     restart: always
-    volumes:
-      - curieproxy_config:/cf-config
     environment:
       - ENVOY_UID
       - TARGET_ADDRESS_A=echo
@@ -55,6 +54,21 @@ services:
     secrets:
       - curieproxysslcrt
       - curieproxysslkey
+
+  extproc:
+    container_name: extproc
+    hostname: extproc
+    image: "curiefense/extproc:${DOCKER_TAG}"
+    restart: always
+    volumes:
+      - curieproxy_config:/cf-config
+    environment:
+      - XFF_TRUSTED_HOPS
+      - EXTPROC_LOG_LEVEL
+    networks:
+      curiemesh:
+        aliases:
+          - extproc
 
   confserver:
     container_name: confserver


### PR DESCRIPTION
This patch adds a new binary, and a new container, using the external
processing filter:

https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_proc/v3/ext_proc.proto#external-processing-filter

This replaces the Lua filter. This increases latency when the system is
not loaded, but greatly increases throughput at scale.

There are still some rough edges related to configuration reloading:

 * because auto reloading is enabled, the code is a bit more complex
   than it should be, because it is not possible to hold a reference to
   the configuration. As a result, a lot of data needs to be copied and
   kept, instead of being a simple reference to the configuration.

 * it is now possible to get concurrent requests asking for
   configuration reloads, which get queued and might choke the system.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>