### PR TITLE
e2e: add option to send bit-flipped requests, use it in CI

### DIFF
--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
             python3 -m venv "$BASEDIR/venv"
             source "$BASEDIR/venv/bin/activate"
-            pip install -U requests pytest pytest-html wheel
+            pip install --no-cache-dir -r "$BASEDIR/e2e/requirements.txt"
 
             pushd "curiefense/curieconf/utils"
             pip install -e .
@@ -46,6 +46,24 @@ jobs:
             pushd e2e
             IP=127.0.0.1
             pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v2/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --junit-xml pytest.xml .
+            popd
+
+            echo "-- Run bitflip tests tests --"
+            # Here we are not interested in the e2e tests results, almost all
+            # of which are expected to fail. We just want to ensure envoy does
+            # not crash with malformed requests.
+            # A subset of tests is selected to exercise most code paths; not
+            # all tests are run to avoid spending more than 5 minutes on this
+            # in CI
+            pushd e2e
+            ENVOY_PID_BEFORE=$(pgrep envoy)
+            IP=127.0.0.1
+            pytest --log-level INFO --base-protected-url http://$IP:30081 --base-conf-url http://$IP:30000/api/v2/ --base-ui-url http://$IP:30080 --elasticsearch-url http://$IP:9200/ --flip-requests . -k 'test_geo or test_ratelimit_scope_include[headers] or test_cookies[active] or test_headers[active] or test_method[active] or test_path[active] or test_query[active] or test_uri[active] or test_nondefault_content_filter_profile_short_headers or test_length_short[cookies] or test_non_allowlisted_value_restrict[ignore_alphanum-headers-regex] or test_content_filter_rule[ignore_alphanum-params-content_filter_rules1] or test_allowlisted_value[no_ignore_alphanum-params-name-norestrict]' || true
+            ENVOY_PID_AFTER=$(pgrep envoy)
+            if [ "$ENVOY_PID_BEFORE" != "$ENVOY_PID_AFTER" ]; then
+              echo "Error: probable envoy crash during bitflip smoke testing"
+              exit 1
+            fi
             popd
 
 

--- a/.github/workflows/e2e-minikube-filebeat.yml
+++ b/.github/workflows/e2e-minikube-filebeat.yml
@@ -41,7 +41,7 @@ jobs:
 
             python3 -m venv "$BASEDIR/venv"
             source "$BASEDIR/venv/bin/activate"
-            pip install -U requests pytest pytest-html wheel
+            pip install --no-cache-dir -r "$BASEDIR/e2e/requirements.txt"
 
             pushd "curiefense/curieconf/utils"
             pip install -e .

--- a/deploy/deploy-dev.sh
+++ b/deploy/deploy-dev.sh
@@ -66,7 +66,7 @@ echo "-- Install curieconfctl --"
 rm -rf "$BASEDIR/venv"
 python3 -m venv "$BASEDIR/venv"
 source "$BASEDIR/venv/bin/activate"
-pip install requests pytest pytest-html wheel
+pip install --no-cache-dir -r "$BASEDIR/curiefense/e2e/requirements.txt"
 
 pip install --no-cache-dir -r "$BASEDIR/curiefense/curiefense/images/confserver/init/requirements.txt"
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -25,3 +25,9 @@ def pytest_addoption(parser):
         help="Elasticsearch URL (ex. http://localhost:9200)",
         default="",
     )
+    parser.addoption(
+        "--flip-requests",
+        help="For each request to the protected urls, also send len(request)*8 requests with 1 flipped bit",
+        action="store_true",
+        default=False,
+    )

--- a/e2e/reqflip.py
+++ b/e2e/reqflip.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import sys
+import requests
+import socket
+from urllib.parse import urlparse
+from requests_toolbelt.utils import dump
+
+
+def raw_send(hostname, port, contents):
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.5)
+            s.connect((hostname, port))
+            s.sendall(contents)
+            s.recv(1000)
+    except socket.timeout:
+        pass
+
+
+def bitflip_send(resp):
+    data = dump.dump_response(resp, request_prefix=b"<<<")
+    req = (
+        b"\n".join([line[3:] for line in data.splitlines() if line.startswith(b"<<<")])
+        + b"\n"
+    )
+    purl = urlparse(resp.url)
+    hostname, port = purl.hostname, purl.port
+    if port is None:
+        port = 80
+    for idx in range(len(req)):
+        for bit in range(8):
+            mask = 1 << bit
+            flipped_req = req[:idx] + bytes([req[idx] ^ mask]) + req[idx + 1 :]
+            raw_send(hostname, port, flipped_req)
+
+
+if __name__ == "__main__":
+    resp = requests.get(sys.argv[1], verify=False)
+    bitflip_send(resp)

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,2 +1,3 @@
 pytest ~= 6.2
 requests ~= 2.25
+requests-toolbelt ~= 0.9.1

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,3 +1,4 @@
-pytest ~= 6.2
-requests ~= 2.25
+pytest ~= 7.1
+requests ~= 2.28
 requests-toolbelt ~= 0.9.1
+wheel ~= 0.37

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Python requirements: pytest requests
+# Python requirements: pytest requests requests_toolbelt
 # install curieconfctl:
 # (cd ../curiefense/curieconf/utils ; pip3 install .)
 # (cd ../curiefense/curieconf/client ; pip3 install .)
@@ -31,6 +31,7 @@
 
 from typing import List, Optional
 from urllib.parse import urlparse
+import reqflip
 import json
 import logging
 import random
@@ -120,8 +121,9 @@ def cli(request):
 
 
 class TargetHelper:
-    def __init__(self, base_url):
+    def __init__(self, base_url, flip):
         self._base_url = base_url
+        self._flip = flip
 
     def query(
         self, path="/", suffix="", method="GET", headers=None, srcip=None, **kwargs
@@ -134,6 +136,10 @@ class TargetHelper:
         res = requests.request(
             method=method, url=self._base_url + path + suffix, headers=headers, **kwargs
         )
+        if self._flip:
+            # Also send copies of the request, flipping bits one by one
+            # This is a "light fuzzing" approach
+            reqflip.bitflip_send(res)
         return res
 
     def is_reachable(self, *args, **kwargs):
@@ -147,7 +153,8 @@ class TargetHelper:
 @pytest.fixture(scope="session")
 def target(request):
     url = request.config.getoption("--base-protected-url").rstrip("/")
-    return TargetHelper(url)
+    flip = request.config.getoption("--flip-requests")
+    return TargetHelper(url, flip)
 
 
 # geo=US, company=SPRINTLINK, asn=1239


### PR DESCRIPTION
This new flag sends the intended HTTP requests, in addition to requests where a single bit from the original HTTP request has been flipped, for all bits in the original request. This is a light unguided fuzzing approach that can be used as a smoke test.

This new flag is used in CI with docker-compose.

This PR also cleans up related e2e tests setup: dependencies are now specified only in e2e/requirements.txt, which relevant scripts reference.