### PR TITLE
Add performance tests that use flow control & rate limits

### DIFF
--- a/deploy/locusttest.sh
+++ b/deploy/locusttest.sh
@@ -16,7 +16,7 @@ for UC in 10 50 100 200 400 500 600; do
 	curl "${LOCUST_URL}/swarm" -X POST -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data-raw "user_count=$UC&spawn_rate=1000&host=http%3A%2F%2Fistio-ingressgateway.istio-system%2Fratings&cf_reqsize=$REQSIZEKB&cf_testid=$TESTID"
 	sleep 60
 
-	curl "${JAEGER_URL}traces?limit=1500&lookback=1h&service=istio-ingressgateway.istio-system&tags=%7B%22http.url%22%3A%22http%3A%2F%2Fistio-ingressgateway.istio-system%2Fratings%2Finvalid%2F${TESTID}%22%7D" --output "$OUTDIR/jaeger-$OUTNAME.json"
+	curl "${JAEGER_URL}traces?limit=1500&lookback=1h&service=istio-ingressgateway.istio-system&tags=%7B%22http.url%22%3A%22http%3A%2F%2Fistio-ingressgateway.istio-system%2Fratings%2Finvalid%3F${TESTID}%22%7D" --output "$OUTDIR/jaeger-$OUTNAME.json"
 	kubectl top --namespace istio-system pod |grep ingress | awk '{print "{\"cpu\":\"" $2 "\", \"ram\":\"" $3 "\"}"}' > "$OUTDIR/resources-$OUTNAME.json"
 	curl "${LOCUST_URL}/stats/requests" --output "$OUTDIR/locust-$OUTNAME.json"
 	curl "${LOCUST_URL}/stop"

--- a/deploy/lua_filter.yaml
+++ b/deploy/lua_filter.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: curiefense-lua-filter
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
+spec:
+  workloadSelector:
+    labels:
+      curiefense: "enabled"
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+    patch:
+      operation: INSERT_BEFORE
+      value: # lua filter specification
+        name: envoy.lua
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+          inlineCode: |
+            local session = require "lua.session_envoy"
+            function envoy_on_request(handle)
+              session.inspect(handle)
+            end

--- a/e2e/set_config.py
+++ b/e2e/set_config.py
@@ -9,7 +9,8 @@ parser.add_argument(
     "-u", "--base-url", help="Base url for API", default="http://localhost:5000/api/v2/"
 )
 parser.add_argument(
-    "CONFIGNAME", choices=["denyall", "defaultconfig", "contentfilter-and-acl"]
+    "CONFIGNAME",
+    choices=["denyall", "defaultconfig", "contentfilter-and-acl", "flow-and-ratelimit"],
 )
 args = parser.parse_args()
 
@@ -22,4 +23,72 @@ elif args.CONFIGNAME == "defaultconfig":
     cli.publish_and_apply()
 elif args.CONFIGNAME == "contentfilter-and-acl":
     cli.revert_and_enable(True, True)
+    cli.publish_and_apply()
+elif args.CONFIGNAME == "flow-and-ratelimit":
+    # Test case that uses redis for every query. Tag-only/monitor to get the
+    # worst possible case: both rate limit & flow control must be evaluated.
+    version = cli.initial_version()
+    cli.call(f"conf revert {test_e2e.TEST_CONFIG_NAME} {version}")
+    # set flow control
+    fl_rules = [
+        {
+            "id": "eff100010001",
+            "name": "Flow Control Monitor",
+            "description": "New Flow Control Notes and Remarks",
+            "active": True,
+            "include": ["all"],
+            "exclude": [],
+            "timeframe": 60,
+            "action": {"type": "monitor"},
+            "key": [{"attrs": "ip"}],
+            "sequence": [
+                {
+                    "method": "GET",
+                    "uri": "/ratings/invalid",
+                    "cookies": {},
+                    "headers": {"host": "www.example.com"},
+                    "args": {},
+                },
+                {
+                    "method": "POST",
+                    "uri": "/ratings/invalid",
+                    "cookies": {},
+                    "headers": {"host": "www.example.com"},
+                    "args": {},
+                },
+            ],
+        }
+    ]
+    cli.call(
+        f"doc update {test_e2e.TEST_CONFIG_NAME} flowcontrol /dev/stdin",
+        inputjson=fl_rules,
+    )
+    # set rate limit
+    rl_rules = [
+        {
+            "id": "ef1100010000",
+            "name": "Rate Limit Example Rule 5/60",
+            "description": "5 requests per minute",
+            "timeframe": "60",
+            "thresholds": [{"limit": "5", "action": {"type": "monitor"}}],
+            "include": ["all"],
+            "exclude": [],
+            "key": [{"attrs": "ip"}],
+            "pairwith": {"self": "self"},
+        }
+    ]
+    cli.call(
+        f"doc update {test_e2e.TEST_CONFIG_NAME} ratelimits /dev/stdin",
+        inputjson=rl_rules,
+    )
+    # set securitypolicy
+    securitypolicy = cli.call(f"doc get {test_e2e.TEST_CONFIG_NAME} securitypolicies")
+    securitypolicy[0]["map"][0]["acl_active"] = False
+    securitypolicy[0]["map"][0]["content_filter_active"] = False
+    securitypolicy[0]["map"][0]["limit_ids"] = ["ef1100010000"]
+    # ## edit
+    cli.call(
+        f"doc update {test_e2e.TEST_CONFIG_NAME} securitypolicies /dev/stdin",
+        inputjson=securitypolicy,
+    )
     cli.publish_and_apply()


### PR DESCRIPTION
In this new performance test configuration, queries trigger both flow-control and ratelimit in tag-only mode, which should be the worst case for redis-related performance. This will help evaluate the performance of planned architecture changes where processing is done using an `ExternalProcessor`.

Sample performance results in the current `main` branch:
![main15e0a8f881d9-payloadsize_0kb](https://user-images.githubusercontent.com/73547485/174446869-8a04d969-3cb8-4217-b1af-6217956ddc6a.png)

