### PR TITLE
bug fix: Same headers

### DIFF
--- a/curiefense/curieproxy/lua/session_nginx.lua
+++ b/curiefense/curieproxy/lua/session_nginx.lua
@@ -17,7 +17,15 @@ function session_rust_nginx.inspect(handle)
     end
 
     for k, v in pairs(rheaders) do
-        headers[k] = v
+        if type(v) == "table" then
+            local new_v = ""
+            for i = 1, #v do
+                new_v = new_v .. " " .. v[i]
+            end
+            headers[k] = new_v
+        else
+            headers[k] = v
+        end
     end
 
     handle.log(handle.INFO, cjson.encode(headers))


### PR DESCRIPTION
When openresty accept more than one headers with a same name, it put the headers' values to a `table`, which lead to a error because Rust code `headers` just accept `HashMap<String, String>`, not `HashMap<String, LuaTable>`.