### PR TITLE
Make uiserver pass requests headers to confserver

### DIFF
--- a/curiefense/images/uiserver/init/http.conf
+++ b/curiefense/images/uiserver/init/http.conf
@@ -10,6 +10,7 @@ server {
 
     location /conf/api/v2/ {
         proxy_pass  http://confserver/api/v2/;
+        proxy_pass_request_headers      on;
     }
 
     location / {


### PR DESCRIPTION
This will allow us to pass authentication information through HTTP
headers.

Signed-off-by: Xavier <xavier@reblaze.com>