### PR TITLE
Prevent crashes when headers are null

### DIFF
--- a/curiefense/curieproxy/lua/session_envoy.lua
+++ b/curiefense/curieproxy/lua/session_envoy.lua
@@ -43,8 +43,10 @@ local function custom_response(handle, action_params)
     if not block_mode then
         handle:logDebug("altering the request")
         local headers = handle:headers()
-        for k, v in pairs(action_params.headers) do
-            headers:replace(k, v)
+        if type(action_params.headers) == "table" then
+            for k, v in pairs(action_params.headers) do
+                headers:replace(k, v)
+            end
         end
         return
     end


### PR DESCRIPTION
Should fix #892

Signed-off-by: Simon Marechal <bartavelle@gmail.com>