### PR TITLE
Prevent creation of globalfilters with empty sections

### DIFF
--- a/curiefense/curieconf/server/curieconf/confserver/v2/api.py
+++ b/curiefense/curieconf/server/curieconf/confserver/v2/api.py
@@ -9,8 +9,10 @@ from curieconf import utils
 from curieconf.utils import cloud
 import requests
 from jsonschema import validate
+from jsonschema.exceptions import ValidationError, SchemaError
 from pathlib import Path
 import json
+from functools import wraps
 
 
 api_bp = Blueprint("api_v2", __name__)
@@ -330,14 +332,26 @@ m_db = api.model("db", {})
 
 ### Document Schema validation
 
+def validate_request(f):
+    def error_message(err):
+        try:
+            return str(err.schema["errors"][err.validator])
+        except KeyError:
+            return err.message
 
-def validateJson(json_data, schema_type):
-    try:
-        validate(instance=json_data, schema=schema_type_map[schema_type])
-    except jsonschema.exceptions.ValidationError as err:
-        print(str(err))
-        return False
-    return True
+    @wraps(f)
+    def decorated_validate_request(*args, **kwargs):
+        if kwargs["document"] not in models:
+            abort(404, "document does not exist")
+        try:
+            validate(instance=request.json,
+                     schema=schema_type_map[kwargs["document"]])
+        except ValidationError as err:
+            abort(400, error_message(err))
+        except SchemaError as err:
+            abort(500, err.message)
+        return f(*args, **kwargs)
+    return decorated_validate_request
 
 
 ### Set git actor according to config & defined HTTP headers
@@ -642,10 +656,9 @@ class EntriesResource(Resource):
         res = current_app.backend.entries_list(config, document)
         return res  # XXX: marshal
 
+    @validate_request
     def post(self, config, document):
         "Create an entry in a document"
-        if document not in models:
-            abort(404, "document does not exist")
         data = marshal(request.json, models[document], skip_none=True)
         res = current_app.backend.entries_create(config, document, data, get_gitactor())
         return res
@@ -660,19 +673,14 @@ class EntryResource(Resource):
         res = current_app.backend.entries_get(config, document, entry)
         return marshal(res, models[document], skip_none=True)
 
+    @validate_request
     def put(self, config, document, entry):
         "Update an entry in a document"
-        if document not in models:
-            abort(404, "document does not exist")
-        isValid = validateJson(request.json, document)
-        if isValid:
-            data = marshal(request.json, models[document], skip_none=True)
-            res = current_app.backend.entries_update(
-                config, document, entry, data, get_gitactor()
-            )
-            return res
-        else:
-            abort(500, "schema mismatched")
+        data = marshal(request.json, models[document], skip_none=True)
+        res = current_app.backend.entries_update(
+            config, document, entry, data, get_gitactor()
+        )
+        return res
 
     def delete(self, config, document, entry):
         "Delete an entry from a document"

--- a/curiefense/curieconf/server/curieconf/confserver/v2/json/global-filters.schema
+++ b/curiefense/curieconf/server/curieconf/confserver/v2/json/global-filters.schema
@@ -64,6 +64,8 @@
         "sections": {
           "type": "array",
           "uniqueItems": true,
+          "title": "Section list",
+          "description": "A list of sections containing matching rules",
           "items": {
             "type": "object",
             "title": "Rule section",
@@ -72,12 +74,27 @@
               "relation": {
                 "relation": "string",
                 "title": "Entries Relationship",
-                "description": "Boolean relation between entries"
+                "description": "For lists with multiple sections, this is the logical relation to use when evaluating the Match Conditions in the sections."
               },
               "entries": {
                 "type": "array",
-                "title": "Entry Description List",
-                "description": "Array must contain exactly 3 items describing the object. Where the first item contains the category, the second item contains the entry, and the last item contains annotation information"
+                "title": "Match conditions List",
+                "minItems": 1,
+                "description": "Definitions of possible characteristics that a request can match (e.g., a list of IP addresses that it might originate from), plus one or more logical operators to use when evaluating the match.",
+                "errors": {
+                  "minItems": "At least one match condition is required"
+                },
+                "items": {
+                  "title": "Match condition",
+                  "description": "A match condition contain the following elements, the first item contains the category, the second item contains the entry, and, optionally, the last item contains extra information",
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 3,
+                  "errors": {
+                    "minItems": "A match condition must contain at least two elements, the first item contains the category and the second item contains the entry",
+                    "maxItems": "A match condition must contain maximum three elements, the first item contains the category, the second item contains the entry and the third item contains extra information"
+                  }
+                }
               }
             }
           }

--- a/curiefense/curieconf/test/test_api_validate_request.py
+++ b/curiefense/curieconf/test/test_api_validate_request.py
@@ -1,0 +1,48 @@
+import pytest
+from curieconf.confserver.v2.api import validate_request, schema_type_map, models
+from werkzeug.exceptions import NotFound, InternalServerError, BadRequest
+from flask import Flask
+from unittest.mock import patch
+
+schema_without_errors_messages = {
+    "list": {
+        "type": "array",
+        "title": "list",
+        "minItems": 2
+    }
+}
+
+invalid_schema = {'schema': 'invalid'}
+
+app = Flask(__name__)
+
+@validate_request
+def do_nothing(document): pass
+
+def test_validate_request_with_non_existent_document():
+
+    with pytest.raises(NotFound) as err:
+        do_nothing(document="non_existent_document")
+
+    assert err.value.code == 404
+    assert err.value.description == "document does not exist"
+
+@patch.dict(models, invalid_schema, clear=True)
+@patch.dict(schema_type_map, invalid_schema, clear=True)
+def test_validate_request_with_invalid_schema():
+
+    with app.test_request_context(json={}), pytest.raises(InternalServerError) as err:
+        do_nothing(document="schema")
+
+    assert err.value.code == 500
+    assert err.value.description == "'invalid' is not of type 'object', 'boolean'"
+
+@patch.dict(models, schema_without_errors_messages)
+@patch.dict(schema_type_map, schema_without_errors_messages)
+def test_validate_request_with_non_existent_error_message():
+
+    with app.test_request_context(json=[]), pytest.raises(BadRequest) as err:
+        do_nothing(document="list")
+
+    assert err.value.code == 400
+    assert err.value.description == "[] is too short"

--- a/curiefense/ui/src/assets/RequestsUtils.ts
+++ b/curiefense/ui/src/assets/RequestsUtils.ts
@@ -53,7 +53,9 @@ const processRequest = (methodName: HttpRequestMethods, apiUrl: string, data: an
     return response
   }).catch((error: Error) => {
     // Toast message
-    if (failureMessage) {
+    if (axios.isAxiosError(error) && error.response && error.response.data.message) {
+      Utils.toast(error.response.data.message, 'is-danger', undoFunction)
+    } else if (failureMessage) {
       Utils.toast(failureMessage, 'is-danger', undoFunction)
     }
     if (typeof onFail === 'function') {

--- a/curiefense/ui/src/assets/__tests__/RequestsUtils.spec.ts
+++ b/curiefense/ui/src/assets/__tests__/RequestsUtils.spec.ts
@@ -130,6 +130,9 @@ describe('RequestsUtils.ts', () => {
         const successMessageClass = 'is-success'
         const failureMessage = 'oops, something went wrong'
         const failureMessageClass = 'is-danger'
+        const axiosError = {
+          response: {data: {message: 'error message'}},
+        }
         let toastOutput: Options[] = []
         beforeEach(() => {
           toastOutput = []
@@ -217,6 +220,16 @@ describe('RequestsUtils.ts', () => {
             done()
           }
           requestFunc('DELETE', urlTrail, null, null, successMessage, failureMessage, null, onFail)
+        })
+
+        test('should send failure toast with a custom message when a request is rejected', (done) => {
+          jest.spyOn(axios, 'isAxiosError').mockImplementationOnce(() => true)
+          jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.reject(axiosError))
+          const onFail = () => {
+            expect(toastOutput[0].message).toContain(axiosError.response.data.message)
+            done()
+          }
+          requestFunc(undefined, urlTrail, null, null, successMessage, failureMessage, null, onFail)
         })
       })
     })


### PR DESCRIPTION
Fixes #776 

The main objectives of this PR are:
- Prevent creation of globalfilters with empty sections
- Instead of using the generic error messages provided by jsonschema exceptions, the idea is to have the error messages defined in the json of each schema, so they can be customized for each schema definition and validator.


Signed-off-by: The Workshop <dev@theworkshop.com>