### PR TITLE
manual build adds 'dev' tag

### DIFF
--- a/.github/workflows/curiefense-manual-build-image.yml
+++ b/.github/workflows/curiefense-manual-build-image.yml
@@ -22,3 +22,13 @@ jobs:
 
             export DOCKER_TAG=${GITHUB_SHA}
             PUSH=1 ./build-docker-images.sh
+
+      - name: add 'dev' tag
+        run: |
+            docker login -u "${{ secrets.DOCKER_HUB_USER }}" -p "${{ secrets.DOCKER_HUB_PASSWORD }}"
+            pushd curiefense/images
+            export DOCKER_TAG=dev
+            PUSH=1 ./build-docker-images.sh
+
+            export DOCKER_TAG=dev
+            PUSH=1 ./build-docker-images.sh


### PR DESCRIPTION
manual build now adds 2 tags:
1. branch name
2. 'dev'

This will allow us to easily test containers in a dev environment using a consistent 'dev' tag