### PR TITLE
Improve deploy-gke.sh doc & messages; update to k8s 1.23

### DIFF
--- a/e2e/latency/Curiefense performance report locust.ipynb
+++ b/e2e/latency/Curiefense performance report locust.ipynb
@@ -113,7 +113,11 @@
     "                print(\"TD\", trace_difference)\n",
     "                print(trace_data)\n",
     "            continue\n",
-    "        d[\"JIstioTimeP50\"] = statistics.quantiles(trace_difference, n=2)[-1]\n",
+    "        try:\n",
+    "            d[\"JIstioTimeP50\"] = statistics.quantiles(trace_difference, n=2)[-1]\n",
+    "        except statistics.StatisticsError as e:\n",
+    "            print(f\"Error on {folder=} {uc=} {reqsize=} {trace_difference=}\", e)\n",
+    "            raise e\n",
     "        d[\"JIstioTimeP75\"] = statistics.quantiles(trace_difference, n=4)[-1]\n",
     "        d[\"JIstioTimeP90\"] = statistics.quantiles(trace_difference, n=10)[-1]\n",
     "        d[\"JIstioTimeP99\"] = statistics.quantiles(trace_difference, n=100)[-1]\n",
@@ -286,7 +290,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.10.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`deploy-gke.sh` improvements:
* k8s 1.20 is no longer available on GKE.
* Added missing requirements to the comments at the beginning of the file, after testing the script with a clean virtualenv

Signed-off-by: Xavier <xavier@reblaze.com>