### PR TITLE
Allow overriding RUST_DISTROS with an env variable in build-docker-images.sh

### DIFF
--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -19,7 +19,7 @@ GITTAG="$(git describe --tag --long --dirty)"
 DOCKER_DIR_HASH="$(git rev-parse --short=12 HEAD:curiefense)"
 DOCKER_TAG="${DOCKER_TAG:-$GITTAG-$DOCKER_DIR_HASH}"
 STOP_ON_FAIL=${STOP_ON_FAIL:-yes}
-RUST_DISTROS=(bionic focal)
+IFS=' ' read -ra RUST_DISTROS <<< "${RUST_DISTROS:-bionic focal}"
 
 if [ -n "$TESTIMG" ]; then
     IMAGES=("$TESTIMG")


### PR DESCRIPTION
This PR facilitates quicker local testing by only building RUST images for a single ubuntu distribution instead of the default value, `bionic focal`.

Signed-off-by: Xavier <xavier@reblaze.com>