### PR TITLE
Lua API change, secpol selection

### DIFF
--- a/curiefense/curieproxy/lua/session_envoy.lua
+++ b/curiefense/curieproxy/lua/session_envoy.lua
@@ -105,7 +105,7 @@ function session_rust_envoy.inspect(handle)
     --   * method : the HTTP verb
     --   * authority : optionally, the HTTP2 authority field
     local res = curiefense.inspect_request(
-        "info", meta, headers, body_content, ip_str
+        {loglevel="info", meta=meta, headers=headers, body=body_content, ip=ip_str}
     )
 
     log_request(handle, res)

--- a/curiefense/curieproxy/lua/session_nginx.lua
+++ b/curiefense/curieproxy/lua/session_nginx.lua
@@ -93,8 +93,8 @@ function session_rust_nginx.inspect(handle, loglevel)
     --   * authority : optionally, the HTTP2 authority field
     local meta = { path=handle.var.request_uri, method=handle.req.get_method(), authority=nil }
 
-    local res = curiefense.inspect_request_init_hops(
-        loglevel, meta, headers, body_content, ip_str, HOPS
+    local res = curiefense.inspect_request_init(
+        {loglevel=loglevel, meta=meta, headers=headers, body=body_content, ip=ip_str, hops=HOPS}
     )
 
     if res.error then

--- a/curiefense/curieproxy/rust/curiefense-externalprocessing/src/server.rs
+++ b/curiefense/curieproxy/rust/curiefense-externalprocessing/src/server.rs
@@ -61,7 +61,7 @@ async fn configloop(rx: Receiver<CfgRequest>, configpath: &str, loglevel: LogLev
 
         let mut logs = Logs::new(loglevel);
         let midata = with_config(configpath, &mut logs, |_, cfg| {
-            inspect_init(cfg, loglevel, meta, IPInfo::Hops(trustedhops as usize), None).map(|o| {
+            inspect_init(cfg, loglevel, meta, IPInfo::Hops(trustedhops as usize), None, None).map(|o| {
                 // we have to clone all this data here :(
                 // that would not be necessary if we could avoid the autoreloading feature, but had a system for reloading the server when the configuration changes
                 let gf = cfg.globalfilters.clone();

--- a/curiefense/curieproxy/rust/curiefense-ffi/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense-ffi/src/lib.rs
@@ -240,7 +240,7 @@ pub async fn inspect_wrapper<GH: Grasshopper>(
     mgh: Option<&GH>,
 ) -> CFDecision {
     let mut mlogs = logs;
-    let result = inspect_generic_request_map_async(&configpath, mgh, raw, &mut mlogs).await;
+    let result = inspect_generic_request_map_async(&configpath, mgh, raw, &mut mlogs, None).await;
     CFDecision { result, logs: mlogs }
 }
 
@@ -475,7 +475,7 @@ pub unsafe extern "C" fn curiefense_stream_start(
         },
     };
     // create the requestinfo structure
-    let init_result = inspect_init(&iconfig.config, iconfig.loglevel, meta, IPInfo::Ip(ip), None);
+    let init_result = inspect_init(&iconfig.config, iconfig.loglevel, meta, IPInfo::Ip(ip), None, None);
     Box::into_raw(Box::new(match init_result {
         Ok(inner) => {
             *success = CFStreamStatus::CFSMore;

--- a/curiefense/curieproxy/rust/curiefense-lua/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense-lua/src/lib.rs
@@ -33,19 +33,35 @@ struct LuaArgs<'l> {
     lua_body: Option<LuaString<'l>>,
     str_ip: String,
     loglevel: LogLevel,
+    secpolid: Option<String>,
+    humanity: Option<bool>,
+    configpath: String,
 }
 
-fn lua_convert_args<'l>(
-    lua: &'l Lua,
-    args: (
-        LuaValue,     // loglevel
-        LuaValue,     // meta
-        LuaValue,     // headers
-        LuaValue<'l>, // optional body
-        LuaValue,     // ip
-    ),
-) -> Result<LuaArgs<'l>, String> {
-    let (vloglevel, vmeta, vheaders, vlua_body, vstr_ip) = args;
+/// Lua function arguments:
+///
+/// All arguments are placed into a Lua table, where the keys are:
+/// * loglevel, mandatory, can be debug, info, warn or err
+/// * meta, table, contains keys "method", "path" and optionally "authority" and "x-request-id"
+/// * headers, table
+/// * body, optional string
+/// * ip, string representation of the IP address
+/// * hops, optional number. When set the IP is computed from the x-forwarded-for header, defaulting to the ip argument on failure
+/// * secpolid, optional string. When set, bypass hostname matching for security policy selection
+/// * configpath, path to the lua configuration files, defaults to /cf-config/current/config
+/// * humanity, optional boolean, only used for the test functions
+fn lua_convert_args<'l>(lua: &'l Lua, args: LuaTable<'l>) -> Result<LuaArgs<'l>, String> {
+    let vloglevel = args.get("loglevel").map_err(|_| "Missing log level".to_string())?;
+    let vmeta = args.get("meta").map_err(|_| "Missing meta argument".to_string())?;
+    let vheaders = args.get("headers").map_err(|_| "Missing headers".to_string())?;
+    let vlua_body = args.get("body").map_err(|_| "Missing body argument".to_string())?;
+    let vstr_ip = args.get("ip").map_err(|_| "Missing ip argument".to_string())?;
+    let vhops = args.get("hops").map_err(|_| "Missing hops argument".to_string())?;
+    let vsecpolid = args
+        .get("secpolid")
+        .map_err(|_| "Missing log level argument".to_string())?;
+    let vhumanity = args.get("human").map_err(|_| "Missing human argument".to_string())?;
+    let vconfigpath = args.get("configpath").map_err(|_| "Missing config path".to_string())?;
     let loglevel = match String::from_lua(vloglevel, lua) {
         Err(rr) => return Err(format!("Could not convert the loglevel argument: {}", rr)),
         Ok(m) => match m.as_str() {
@@ -72,42 +88,51 @@ fn lua_convert_args<'l>(
         Err(rr) => return Err(format!("Could not convert the ip argument: {}", rr)),
         Ok(i) => i,
     };
+    let hops = match FromLua::from_lua(vhops, lua) {
+        Err(rr) => return Err(format!("Could not convert the hops argument: {}", rr)),
+        Ok(i) => i,
+    };
+    let secpolid = match FromLua::from_lua(vsecpolid, lua) {
+        Err(rr) => return Err(format!("Could not convert the hops argument: {}", rr)),
+        Ok(i) => i,
+    };
+    let ip = match hops {
+        None => str_ip,
+        Some(hops) => curiefense::incremental::extract_ip(hops, &headers).unwrap_or(str_ip),
+    };
+    let humanity = match FromLua::from_lua(vhumanity, lua) {
+        Err(rr) => return Err(format!("Could not convert the humanity argument: {}", rr)),
+        Ok(h) => h,
+    };
+    let configpath: Option<String> = match FromLua::from_lua(vconfigpath, lua) {
+        Err(rr) => return Err(format!("Could not convert the config path argument: {}", rr)),
+        Ok(p) => p,
+    };
     Ok(LuaArgs {
         meta,
         headers,
         lua_body,
-        str_ip,
+        str_ip: ip,
         loglevel,
+        secpolid,
+        humanity,
+        configpath: configpath.unwrap_or_else(|| "/cf-config/current/config".to_string()),
     })
 }
 
 /// Lua interface to the inspection function
-///
-/// args are
-/// * meta (contains keys "method", "path" and optionally "authority" and "x-request-id")
-/// * headers
-/// * (opt) body
-/// * ip addr
-fn lua_inspect_request(
-    lua: &Lua,
-    args: (
-        LuaValue, // log level
-        LuaValue, // meta
-        LuaValue, // headers
-        LuaValue, // optional body
-        LuaValue, // ip
-    ),
-) -> LuaResult<LuaInspectionResult> {
+fn lua_inspect_request(lua: &Lua, args: LuaTable) -> LuaResult<LuaInspectionResult> {
     match lua_convert_args(lua, args) {
         Ok(lua_args) => {
             let grasshopper = &DynGrasshopper {};
             let res = inspect_request(
-                "/cf-config/current/config",
+                &lua_args.configpath,
                 lua_args.meta,
                 lua_args.headers,
                 lua_args.lua_body.as_ref().map(|b| b.as_bytes()),
                 lua_args.str_ip,
                 Some(grasshopper),
+                lua_args.secpolid,
             );
             Ok(LuaInspectionResult(res))
         }
@@ -118,67 +143,19 @@ fn lua_inspect_request(
 /// ****************************************
 /// Lua interface for the "async dialog" API
 /// ****************************************
-
-/// This is the initialization function, that will return a list of items to check
-fn lua_inspect_init_hops(
-    lua: &Lua,
-    args: (
-        LuaValue, // log level
-        LuaValue, // meta
-        LuaValue, // headers
-        LuaValue, // optional body
-        LuaValue, // known ip
-        LuaValue, // hops
-    ),
-) -> LuaResult<LInitResult> {
-    let (loglevel, meta, headers, body, ip, lhops) = args;
-    let hops = FromLua::from_lua(lhops, lua)?;
-    match lua_convert_args(lua, (loglevel, meta, headers, body, ip)) {
-        Ok(lua_args) => {
-            let grasshopper = &DynGrasshopper {};
-            let ip = curiefense::incremental::extract_ip(hops, &lua_args.headers).unwrap_or(lua_args.str_ip);
-            let res = inspect_init(
-                lua_args.loglevel,
-                "/cf-config/current/config",
-                lua_args.meta,
-                lua_args.headers,
-                lua_args.lua_body.as_ref().map(|b| b.as_bytes()),
-                ip,
-                Some(grasshopper),
-            );
-            Ok(match res {
-                Ok((r, logs)) => match r {
-                    InitResult::Res(r) => LInitResult::P0Result(Box::new(InspectionResult::from_analyze(logs, r))),
-                    InitResult::Phase1(p1) => LInitResult::P1(logs, Box::new(p1)),
-                },
-                Err(s) => LInitResult::P0Error(s),
-            })
-        }
-        Err(rr) => Ok(LInitResult::P0Error(rr)),
-    }
-}
-
-fn lua_inspect_init(
-    lua: &Lua,
-    args: (
-        LuaValue, // log level
-        LuaValue, // meta
-        LuaValue, // headers
-        LuaValue, // optional body
-        LuaValue, // ip
-    ),
-) -> LuaResult<LInitResult> {
+fn lua_inspect_init(lua: &Lua, args: LuaTable) -> LuaResult<LInitResult> {
     match lua_convert_args(lua, args) {
         Ok(lua_args) => {
             let grasshopper = &DynGrasshopper {};
             let res = inspect_init(
                 lua_args.loglevel,
-                "/cf-config/current/config",
+                &lua_args.configpath,
                 lua_args.meta,
                 lua_args.headers,
                 lua_args.lua_body.as_ref().map(|b| b.as_bytes()),
                 lua_args.str_ip,
                 Some(grasshopper),
+                lua_args.secpolid,
             );
             Ok(match res {
                 Ok((r, logs)) => match r {
@@ -193,11 +170,7 @@ fn lua_inspect_init(
 }
 
 /// This is the processing function, that will an analysis result
-fn lua_inspect_process(
-    lua: &Lua,
-    // args: (LInitResult, Vec<LuaFlowResult>, Vec<LuaLimitResult>),
-    args: (LuaValue, LuaValue, LuaValue),
-) -> LuaResult<LuaInspectionResult> {
+fn lua_inspect_process(lua: &Lua, args: (LuaValue, LuaValue, LuaValue)) -> LuaResult<LuaInspectionResult> {
     let (lpred, lflow_results, llimit_results) = args;
     let lerr = |msg| Ok(LuaInspectionResult(Err(msg)));
     let pred = match FromLua::from_lua(lpred, lua) {
@@ -252,38 +225,27 @@ impl Grasshopper for DummyGrasshopper {
 
 /// Lua TEST interface to the inspection function
 /// allows settings the Grasshopper result!
-///
-/// args are
-/// * meta (contains keys "method", "path", and optionally "authority")
-/// * headers
-/// * (opt) body
-/// * ip addr
-/// * (opt) grasshopper
 #[allow(clippy::type_complexity)]
 #[allow(clippy::unnecessary_wraps)]
-fn lua_test_inspect_request(
-    _lua: &Lua,
-    args: (
-        HashMap<String, String>, // meta
-        HashMap<String, String>, // headers
-        Option<LuaString>,       // maybe body
-        String,                  // ip
-        bool,                    // humanity
-    ),
-) -> LuaResult<LuaInspectionResult> {
-    let (meta, headers, lua_body, str_ip, humanity) = args;
-    let gh = DummyGrasshopper { humanity };
-    let grasshopper = Some(&gh);
-
-    let res = inspect_request(
-        "/cf-config/current/config",
-        meta,
-        headers,
-        lua_body.as_ref().map(|b| b.as_bytes()),
-        str_ip,
-        grasshopper,
-    );
-    Ok(LuaInspectionResult(res))
+fn lua_test_inspect_request(lua: &Lua, args: LuaTable) -> LuaResult<LuaInspectionResult> {
+    match lua_convert_args(lua, args) {
+        Ok(lua_args) => {
+            let gh = DummyGrasshopper {
+                humanity: lua_args.humanity.unwrap_or(false),
+            };
+            let res = inspect_request(
+                &lua_args.configpath,
+                lua_args.meta,
+                lua_args.headers,
+                lua_args.lua_body.as_ref().map(|b| b.as_bytes()),
+                lua_args.str_ip,
+                Some(&gh),
+                lua_args.secpolid,
+            );
+            Ok(LuaInspectionResult(res))
+        }
+        Err(rr) => Ok(LuaInspectionResult(Err(rr))),
+    }
 }
 
 /// Rust-native inspection top level function
@@ -294,6 +256,7 @@ fn inspect_request<GH: Grasshopper>(
     mbody: Option<&[u8]>,
     ip: String,
     grasshopper: Option<&GH>,
+    selected_secpol: Option<String>,
 ) -> Result<InspectionResult, String> {
     let mut logs = Logs::default();
     logs.debug("Inspection init");
@@ -305,11 +268,12 @@ fn inspect_request<GH: Grasshopper>(
         headers,
         mbody,
     };
-    let dec = inspect_generic_request_map(configpath, grasshopper, raw, &mut logs);
+    let dec = inspect_generic_request_map(configpath, grasshopper, raw, &mut logs, selected_secpol.as_deref());
 
     Ok(InspectionResult::from_analyze(logs, dec))
 }
 /// Rust-native functions for the dialog system
+#[allow(clippy::too_many_arguments)]
 fn inspect_init<GH: Grasshopper>(
     loglevel: LogLevel,
     configpath: &str,
@@ -318,6 +282,7 @@ fn inspect_init<GH: Grasshopper>(
     mbody: Option<&[u8]>,
     ip: String,
     grasshopper: Option<&GH>,
+    selected_secpol: Option<String>,
 ) -> Result<(InitResult, Logs), String> {
     let mut logs = Logs::new(loglevel);
     logs.debug("Inspection init");
@@ -330,7 +295,8 @@ fn inspect_init<GH: Grasshopper>(
         mbody,
     };
 
-    let p0 = match inspect_generic_request_map_init(configpath, grasshopper, raw, &mut logs) {
+    let p0 = match inspect_generic_request_map_init(configpath, grasshopper, raw, &mut logs, selected_secpol.as_deref())
+    {
         Err(res) => return Ok((InitResult::Res(res), logs)),
         Ok(p0) => p0,
     };
@@ -348,14 +314,13 @@ fn curiefense(lua: &Lua) -> LuaResult<LuaTable> {
     // end-to-end inspection
     exports.set("inspect_request", lua.create_function(lua_inspect_request)?)?;
     exports.set("inspect_request_init", lua.create_function(lua_inspect_init)?)?;
-    exports.set("inspect_request_init_hops", lua.create_function(lua_inspect_init_hops)?)?;
     exports.set("inspect_request_process", lua.create_function(lua_inspect_process)?)?;
-    // end-to-end inspection (test)
-    exports.set("test_inspect_request", lua.create_function(lua_test_inspect_request)?)?;
     exports.set(
         "aggregated_values",
         lua.create_function(|_, ()| Ok(aggregated_values_block()))?,
     )?;
+    // end-to-end inspection (test)
+    exports.set("test_inspect_request", lua.create_function(lua_test_inspect_request)?)?;
 
     Ok(exports)
 }

--- a/curiefense/curieproxy/rust/curiefense-py/src/lib.rs
+++ b/curiefense/curieproxy/rust/curiefense-py/src/lib.rs
@@ -37,7 +37,7 @@ fn py_inspect_request(
     };
 
     let grasshopper = DynGrasshopper {};
-    let dec = inspect_generic_request_map(&configpath, Some(&grasshopper), raw, &mut logs);
+    let dec = inspect_generic_request_map(&configpath, Some(&grasshopper), raw, &mut logs, None);
     let res = InspectionResult {
         decision: dec.decision,
         tags: Some(dec.tags),

--- a/curiefense/curieproxy/rust/curiefense/benches/security_policies.rs
+++ b/curiefense/curieproxy/rust/curiefense/benches/security_policies.rs
@@ -98,8 +98,8 @@ fn forms_string_map(c: &mut Criterion) {
             let cfg = gen_bogus_config(size);
             b.iter(|| {
                 let mut logs = Logs::default();
-                let umap =
-                    match_securitypolicy("my.host.name", "/non/matching/path", black_box(&cfg), &mut logs).unwrap();
+                let umap = match_securitypolicy("my.host.name", "/non/matching/path", black_box(&cfg), &mut logs, None)
+                    .unwrap();
                 assert_eq!(umap.entry.name, "selected");
             })
         });

--- a/curiefense/curieproxy/rust/curiefense/src/config/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/mod.rs
@@ -91,6 +91,7 @@ where
 #[derive(Debug, Clone)]
 pub struct Config {
     pub revision: String,
+    pub securitypolicies_map: HashMap<String, HostMap>, // used when the security policy is set
     pub securitypolicies: Vec<Matching<HostMap>>,
     pub globalfilters: Vec<GlobalFilterSection>,
     pub default: Option<HostMap>,
@@ -213,6 +214,7 @@ impl Config {
     ) -> Config {
         let mut default: Option<HostMap> = None;
         let mut securitypolicies: Vec<Matching<HostMap>> = Vec::new();
+        let mut securitypolicies_map = HashMap::new();
         let mut logs = logs;
 
         let (limits, global_limits, inactive_limits) = Limit::resolve(&mut logs, actions, rawlimits);
@@ -268,6 +270,7 @@ impl Config {
                 entries,
                 default: default_entry,
             };
+            securitypolicies_map.insert(rawmap.id, hostmap.clone());
             if rawmap.match_ == "__default__" {
                 if default.is_some() {
                     logs.error(|| format!("HostMap entry '{}' has several default entries", hostmap.name));
@@ -294,6 +297,7 @@ impl Config {
 
         Config {
             revision,
+            securitypolicies_map,
             securitypolicies,
             globalfilters,
             default,
@@ -414,6 +418,7 @@ impl Config {
     pub fn empty() -> Config {
         Config {
             revision: "dummy".to_string(),
+            securitypolicies_map: HashMap::new(),
             securitypolicies: Vec::new(),
             globalfilters: Vec::new(),
             last_mod: SystemTime::UNIX_EPOCH,

--- a/curiefense/curieproxy/rust/curiefense/src/incremental.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/incremental.rs
@@ -75,6 +75,7 @@ pub fn inspect_init(
     meta: RequestMeta,
     ipinfo: IPInfo,
     start: Option<DateTime<Utc>>,
+    selected_secpol: Option<&str>,
 ) -> Result<IData, String> {
     let mut logs = Logs::new(loglevel);
     let mr = match_securitypolicy(
@@ -82,6 +83,7 @@ pub fn inspect_init(
         &meta.path,
         config,
         &mut logs,
+        selected_secpol,
     );
     match mr {
         None => Err("could not find a matching security policy".to_string()),
@@ -276,6 +278,7 @@ mod test {
     fn empty_config(cf: ContentFilterProfile) -> Config {
         Config {
             revision: "dummy".to_string(),
+            securitypolicies_map: HashMap::new(),
             securitypolicies: Vec::new(),
             globalfilters: Vec::new(),
             default: Some(HostMap {
@@ -324,6 +327,7 @@ mod test {
                 requestid: None,
             },
             IPInfo::Ip("1.2.3.4".to_string()),
+            None,
             None,
         )
         .unwrap()

--- a/curiefense/curieproxy/rust/luatests/test.lua
+++ b/curiefense/curieproxy/rust/luatests/test.lua
@@ -110,12 +110,15 @@ local function run_inspect_request_gen(raw_request_map, mode)
     end
     local res
     if human ~= nil then
-      res = curiefense.test_inspect_request(meta, headers, raw_request_map.body, ip, human)
+      res = curiefense.test_inspect_request({loglevel="debug", meta=meta,
+              headers=headers, body=raw_request_map.body, ip=ip, human=human})
     else
       if mode ~= "lua_async" then
-        res = curiefense.inspect_request("debug", meta, headers, raw_request_map.body, ip)
+        res = curiefense.inspect_request({loglevel="debug", meta=meta, headers=headers,
+                body=raw_request_map.body, ip=ip})
       else
-        local r1 = curiefense.inspect_request_init("debug", meta, headers, raw_request_map.body, ip)
+        local r1 = curiefense.inspect_request_init({loglevel="debug", meta=meta,
+                    headers=headers, body=raw_request_map.body, ip=ip})
         if r1.error then
           error(r1.error)
         end


### PR DESCRIPTION
The Lua API has been modified:

 * arguments are passed in a single table, as described below,
 * it is now possible to force the secpolid, and bypass hostname selection

All arguments are placed into a Lua table, where the keys are:
 * loglevel, mandatory, can be debug, info, warn or err
 * meta, table, contains keys "method", "path" and optionally "authority" and "x-request-id"
 * headers, table
 * body, optional string
 * ip, string representation of the IP address
 * hops, optional number. When set the IP is computed from the x-forwarded-for header, defaulting to the ip argument on failure
 * secpolid, optional string. When set, bypass hostname matching for security policy selection
 * configpath, path to the lua configuration files, defaults to cf-config/current/config
 * humanity, optional boolean, only used for the test functions

Signed-off-by: Simon Marechal <bartavelle@gmail.com>