### PR TITLE
Update envoy in docker-compose image, use upstream binary

### DIFF
--- a/curiefense/curieproxy/envoy.yaml.head
+++ b/curiefense/curieproxy/envoy.yaml.head
@@ -1,8 +1,15 @@
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
 static_resources:
   listeners:
-  - name: main
+  - name: listener_0
     address:
       socket_address:
+        protocol: TCP
         address: 0.0.0.0
         port_value: 80
     filter_chains:
@@ -10,6 +17,8 @@ static_resources:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          scheme_header_transformation:
+            scheme_to_overwrite: https
           stat_prefix: ingress_http
           codec_type: auto
           use_remote_address: true
@@ -41,16 +50,18 @@ static_resources:
           - name: envoy.filters.http.lua
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local session = require "lua.session_envoy"
-                function envoy_on_request(handle)
-                  session.inspect(handle)
-                end
-                function envoy_on_response(handle)
-                  session.on_response(handle)
-                end
+              default_source_code:
+                inline_string: |
+                  local session = require "lua.session_envoy"
+                  function envoy_on_request(handle)
+                    session.inspect(handle)
+                  end
+                  function envoy_on_response(handle)
+                    session.on_response(handle)
+                  end
           - name: envoy.filters.http.router
-            typed_config: {}
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   - name: secondary
     address:
@@ -94,13 +105,15 @@ static_resources:
           - name: envoy.filters.http.lua
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local session = require "lua.session_envoy"
-                function envoy_on_request(handle)
-                  session.inspect(handle)
-                end
-                function envoy_on_response(handle)
-                  session.on_response(handle)
-                end
+              default_source_code:
+                inline_string: |
+                  local session = require "lua.session_envoy"
+                  function envoy_on_request(handle)
+                    session.inspect(handle)
+                  end
+                  function envoy_on_response(handle)
+                    session.on_response(handle)
+                  end
           - name: envoy.filters.http.router
-            typed_config: {}
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/curiefense/curieproxy/envoy.yaml.tail
+++ b/curiefense/curieproxy/envoy.yaml.tail
@@ -2,6 +2,8 @@
   - name: target_site_a
     connect_timeout: 25s
     type: strict_dns # static
+    # Comment out the following line to test on v6 networks
+    dns_lookup_family: V4_ONLY
     lb_policy: round_robin
     load_assignment:
       cluster_name: target_site_a
@@ -15,6 +17,8 @@
   - name: target_site_b
     connect_timeout: 25s
     type: strict_dns # static
+    # Comment out the following line to test on v6 networks
+    dns_lookup_family: V4_ONLY
     lb_policy: round_robin
     load_assignment:
       cluster_name: target_site_b
@@ -25,10 +29,3 @@
               socket_address:
                 address: TARGET_ADDRESS_B
                 port_value: TARGET_PORT_B
-
-admin:
-  access_log_path: "/dev/null"
-  address:
-    socket_address:
-      address: 0.0.0.0
-      port_value: 8001

--- a/curiefense/curieproxy/envoy.yaml.tls
+++ b/curiefense/curieproxy/envoy.yaml.tls
@@ -39,16 +39,18 @@
           - name: envoy.filters.http.lua
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local session = require "lua.session_envoy"
-                function envoy_on_request(handle)
-                  session.inspect(handle)
-                end
-                function envoy_on_response(handle)
-                  session.on_response(handle)
-                end
+              default_source_code:
+                inline_string: |
+                  local session = require "lua.session_envoy"
+                  function envoy_on_request(handle)
+                    session.inspect(handle)
+                  end
+                  function envoy_on_response(handle)
+                    session.on_response(handle)
+                  end
           - name: envoy.filters.http.router
-            typed_config: {}
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       transport_socket:
         name: envoy.transport_sockets.tls
         typed_config:
@@ -101,16 +103,18 @@
           - name: envoy.filters.http.lua
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local session = require "lua.session_envoy"
-                function envoy_on_request(handle)
-                  session.inspect(handle)
-                end
-                function envoy_on_response(handle)
-                  session.on_response(handle)
-                end
+              default_source_code:
+                inline_string: |
+                  local session = require "lua.session_envoy"
+                  function envoy_on_request(handle)
+                    session.inspect(handle)
+                  end
+                  function envoy_on_response(handle)
+                    session.on_response(handle)
+                  end
           - name: envoy.filters.http.router
-            typed_config: {}
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       transport_socket:
         name: envoy.transport_sockets.tls
         typed_config:

--- a/curiefense/images/curieproxy-envoy/Dockerfile
+++ b/curiefense/images/curieproxy-envoy/Dockerfile
@@ -1,7 +1,6 @@
 ARG RUSTBIN_TAG=latest
 FROM curiefense/curiefense-rustbuild-bionic:${RUSTBIN_TAG} AS rustbin
-FROM curiefense/envoy-cf:8218a88a1ae76b7657ae226e5542e6f4058d9921 AS envoy-cf
-FROM envoyproxy/envoy:v1.21.1
+FROM envoyproxy/envoy:v1.23.1
 
 RUN apt-get update && \
     apt-get -qq -y --no-install-recommends install jq luarocks libpcre2-dev libgeoip-dev \
@@ -21,9 +20,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.13.3-amd64.deb && dpkg -i filebeat-7.13.3-amd64.deb && rm filebeat-7.13.3-amd64.deb
-
-# Overwrite stripped envoy with full symbol
-COPY --from=envoy-cf /envoy /usr/local/bin/envoy
 
 COPY init/start_curiefense.sh /start_curiefense.sh
 COPY curieproxy/lua /lua


### PR DESCRIPTION
Upstream envoy binaries now support using lua, so we do not need to compile them with debug symbols.

Signed-off-by: Xavier <xavier@reblaze.com>