### PR TITLE
feat: redis key prefix

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/flow.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/flow.rs
@@ -6,6 +6,7 @@ use crate::Logs;
 use crate::config::flow::{FlowElement, FlowMap, SequenceKey};
 use crate::config::matchers::RequestSelector;
 use crate::interface::{Location, Tags};
+use crate::redis::REDIS_KEY_PREFIX;
 use crate::utils::{check_selector_cond, select_string, RequestInfo};
 
 fn session_sequence_key(ri: &RequestInfo) -> SequenceKey {
@@ -23,7 +24,7 @@ fn build_redis_key(
     for kpart in key.iter() {
         tohash += &select_string(reqinfo, kpart, Some(tags))?;
     }
-    Some(format!("{:X}", md5::compute(tohash)))
+    Some(format!("{}{:X}", *REDIS_KEY_PREFIX, md5::compute(tohash)))
 }
 
 fn flow_match(reqinfo: &RequestInfo, tags: &Tags, elem: &FlowElement) -> bool {

--- a/curiefense/curieproxy/rust/curiefense/src/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/limit.rs
@@ -1,5 +1,6 @@
 use crate::interface::stats::{BStageFlow, BStageLimit, StatsCollect};
 use crate::logs::Logs;
+use crate::redis::REDIS_KEY_PREFIX;
 use redis::aio::ConnectionManager;
 
 use crate::config::limit::Limit;
@@ -12,7 +13,7 @@ fn build_key(reqinfo: &RequestInfo, tags: &Tags, limit: &Limit) -> Option<String
     for kpart in limit.key.iter().map(|r| select_string(reqinfo, r, Some(tags))) {
         key += &kpart?;
     }
-    Some(format!("{:X}", md5::compute(key)))
+    Some(format!("{}{:X}", *REDIS_KEY_PREFIX, md5::compute(key)))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/curiefense/curieproxy/rust/curiefense/src/redis.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/redis.rs
@@ -3,6 +3,12 @@ use redis::{ConnectionAddr, ConnectionInfo, RedisConnectionInfo};
 
 lazy_static! {
     static ref RPOOL: anyhow::Result<redis::aio::ConnectionManager> = async_std::task::block_on(build_pool());
+    pub static ref REDIS_KEY_PREFIX: String = std::env::var("REDIS_KEY_PREFIX")
+        .and_then(|mut prefix| {
+            prefix.push('_');
+            Ok(prefix)
+        })
+        .unwrap_or_default();
 }
 
 /// creates an async connection to a redis server


### PR DESCRIPTION
## Description

Add an environment variable `REDIS_KEY_PREFIX`, which will be used as a prefix for all redis keys.

The resulting key will look like `<REDIS_KEY_PREFIX>_<ACTUAL_KEY>`
