### PR TITLE
feat: autotag geoip traits

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/tagging.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/tagging.rs
@@ -238,6 +238,16 @@ pub fn tag_request(
         rinfo.rinfo.geoip.network.as_deref().unwrap_or("nil"),
         Location::Ip,
     );
+    if let Some(is_anonymous_proxy) = rinfo.rinfo.geoip.is_anonymous_proxy {
+        if is_anonymous_proxy {
+            tags.insert("mm-anon", Location::Ip)
+        }
+    }
+    if let Some(is_satellite_provider) = rinfo.rinfo.geoip.is_satellite_provider {
+        if is_satellite_provider {
+            tags.insert("mm-sat", Location::Ip)
+        }
+    }
 
     let mut matched = 0;
     let mut decision = SimpleDecision::Pass;


### PR DESCRIPTION
## Description

Add autotag for traits in maxmind geoip (`is_anonymous_proxy` & `is_satellite_provider`).

Those traits are only available in the GeoIP2 commercial database, it is therefore impossible to write test for theses tags.