### PR TITLE
Update istio 1.15

### DIFF
--- a/curiefense/images/curieproxy-istio/Dockerfile
+++ b/curiefense/images/curieproxy-istio/Dockerfile
@@ -1,11 +1,10 @@
 ARG RUSTBIN_TAG=latest
 FROM curiefense/curiefense-rustbuild-focal:${RUSTBIN_TAG} AS rustbin
-FROM curiefense/envoy-istio-cf:407e092226b2c0913357b16ddf0917cf71e69dd4 AS envoy-istio-cf
-FROM docker.io/istio/proxyv2:1.13.2
+FROM docker.io/istio/proxyv2:1.15.2
 
 RUN apt-get update && \
     apt-get -yq --no-install-recommends install jq luarocks libpcre2-dev \
-    libgeoip-dev python dumb-init gcc g++ make unzip libhyperscan[45] libhyperscan-dev && \
+    libgeoip-dev python3 dumb-init gcc g++ make unzip libhyperscan[45] libhyperscan-dev && \
     luarocks install lrexlib-pcre2 && \
     luarocks install lua-cjson && \
     luarocks install lua-resty-string && \
@@ -19,9 +18,6 @@ RUN apt-get update && \
     apt-get remove -y jq luarocks libpcre2-dev libgeoip-dev python \
     gcc g++ make unzip libhyperscan-dev && apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
-
-# Overwrite stripped envoy with full symbol
-COPY --from=envoy-istio-cf /envoy /usr/local/bin/envoy
 
 COPY init/start_curiefense_pilot.sh /start_curiefense_pilot.sh
 COPY curieproxy/lua /lua

--- a/deploy/istio-helm/charts/gateways/istio-ingress/templates/curiefense_lua_filter.yaml
+++ b/deploy/istio-helm/charts/gateways/istio-ingress/templates/curiefense_lua_filter.yaml
@@ -16,12 +16,15 @@ spec:
     patch:
       operation: INSERT_BEFORE
       value: # lua filter specification
-        name: envoy.lua
+        name: envoy.filters.http.lua
         typed_config:
           "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
           inlineCode: |
             local session = require "lua.session_envoy"
             function envoy_on_request(handle)
               session.inspect(handle)
+            end
+            function envoy_on_response(handle)
+              session.on_response(handle)
             end
 {{- end }}


### PR DESCRIPTION
This updates curiefense to use istio 1.15.2 instead of 1.13.2. Since envoy has been updated upstream to have all lua support features that curiefense needs, we no longer need to build custom envoy binaries, which makes updates significantly easier.

E2E tests on minikube on this PR are expected to fail, as these tests will use charts designed for istio 1.13.2. I have done some manual testing (blocking all requests works) in addition to running performance tests.

Right after this PR is merged, the charts must be updated by merging [this PR in curiefense-helm](https://github.com/curiefense/curiefense-helm/pull/30).

No performance regression identified in this PR, numbers even look a little better than with the last release of curiefense.
![compare-cf-1 5 0-with-istio-1 15-65e11--config_defaultconfig](https://user-images.githubusercontent.com/73547485/197170722-7c64313b-6cd9-4b57-93c9-d5656da3263c.png)
![compare-cf-1 5 0-with-istio-1 15-65e11--config_denyall](https://user-images.githubusercontent.com/73547485/197170737-06175cf9-d34d-4419-9430-fb8b62edc094.png)
![compare-cf-1 5 0-with-istio-1 15-65e11--payloadsize_0kb](https://user-images.githubusercontent.com/73547485/197170745-6acfbba3-592f-4584-ae50-f63bdfe91a6b.png)
