### PR TITLE
adding mongodb to docker compose

### DIFF
--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -275,6 +275,18 @@ services:
   #   ports:
   #     - 5601:5601
 
+  mongodb:
+    container_name: mongodb
+    hostname: mongodb
+    image: docker.io/bitnami/mongodb:6.0
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - 'mongodb_data:/bitnami/mongodb'
+    networks:
+      - curiemesh
+
 networks:
   curiemesh:
     name: curiemesh
@@ -295,6 +307,8 @@ volumes:
   local_bucket:
   # shared between curiesync and curieproxy
   curieproxy_config:
+  mongodb_data:
+    driver: local
 
 secrets:
   s3cfg:


### PR DESCRIPTION
Signed-off-by: yitzchake <yitzchake@reblaze.com>

MongoDB added to docker compose.

Can be reached by other containers:
![image](https://user-images.githubusercontent.com/92663724/197334860-8bde93bf-77a9-490e-a626-658baa7df60b.png)
