### PR TITLE
fix: remove "default content" as empty action response

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
@@ -466,11 +466,7 @@ impl SimpleAction {
             RawActionType::Skip => SimpleActionT::Skip,
             RawActionType::Monitor => SimpleActionT::Monitor,
             RawActionType::Custom => SimpleActionT::Custom {
-                content: rawaction
-                    .params
-                    .content
-                    .clone()
-                    .unwrap_or_else(|| "default content".into()),
+                content: rawaction.params.content.clone().unwrap_or_default(),
             },
             RawActionType::Challenge => SimpleActionT::Challenge,
         };


### PR DESCRIPTION
## Description

Change the default response of empty custom action.

Previously, when a custom action did not contain any content, the response was a sample message containing `default content`.
Now, the response is an empty message.