### PR TITLE
Update build-docker-images.sh

### DIFF
--- a/curiefense/images/build-docker-images.sh
+++ b/curiefense/images/build-docker-images.sh
@@ -15,10 +15,16 @@ BUILD_RUST=${BUILD_RUST:-yes}
 declare -A status
 
 GLOBALSTATUS=0
-GITTAG="$(git describe --tag --long --dirty)"
-DOCKER_DIR_HASH="$(git rev-parse --short=12 HEAD:curiefense)"
-DOCKER_TAG="${DOCKER_TAG:-$GITTAG-$DOCKER_DIR_HASH}"
+
+if [ -z "$DOCKER_TAG" ]
+then
+    GITTAG="$(git describe --tag --long --dirty)"
+    DOCKER_DIR_HASH="$(git rev-parse --short=12 HEAD:curiefense)"
+    DOCKER_TAG="${DOCKER_TAG:-$GITTAG-$DOCKER_DIR_HASH}"
+fi
+
 STOP_ON_FAIL=${STOP_ON_FAIL:-yes}
+
 IFS=' ' read -ra RUST_DISTROS <<< "${RUST_DISTROS:-bionic focal}"
 
 if [ -n "$TESTIMG" ]; then


### PR DESCRIPTION
@xavier-rbz many time we clone with `git clone --depth=1` jsut to get the latest.
in those cases, the command
```
git describe --tag --long --dirty
```
produces:
```
fatal: No names found, cannot describe anything.
```

to avoid this, I suggest the following changes
