### PR TITLE
Ignore shellcheck for quotes in envsubst calls

### DIFF
--- a/curiefense/images/curieproxy-nginx/start.sh
+++ b/curiefense/images/curieproxy-nginx/start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# shellcheck disable=SC2016
 envsubst '${TARGET_ADDRESS_A},${TARGET_PORT_A},${TARGET_ADDRESS_B},${TARGET_PORT_B},${AGGREGATED_STATS_LOG_FILE},${NGINX_ACCESS_LOG},${NGINX_ERROR_LOG},${CF_LOG_LEVEL},${NGINX_LOG_LEVEL}' < /usr/local/openresty/nginx/conf/nginx.conf > /usr/local/openresty/nginx/conf/nginx.conf.1
 mv /usr/local/openresty/nginx/conf/nginx.conf.1 /usr/local/openresty/nginx/conf/nginx.conf
 


### PR DESCRIPTION
Fixes shellcheck that was broken in https://github.com/curiefense/curiefense/commit/7b369a61b51b488b74691a8143f41d0588dd0495
Let's not break CI.

Signed-off-by: Xavier <xavier@reblaze.com>