### PR TITLE
fix: add skip action tags

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
@@ -531,14 +531,14 @@ impl SimpleAction {
         tags: &mut Tags,
         reason: Vec<BlockReason>,
     ) -> Decision {
+        for t in self.extra_tags.iter().flat_map(|s| s.iter()) {
+            tags.insert(t, Location::Request);
+        }
         if self.atype == SimpleActionT::Skip {
             return Decision {
                 maction: None,
                 reasons: reason,
             };
-        }
-        for t in self.extra_tags.iter().flat_map(|s| s.iter()) {
-            tags.insert(t, Location::Request);
         }
         let action = match self.to_action(rinfo, tags, is_human) {
             None => match (mgh, rinfo.headers.get("user-agent")) {


### PR DESCRIPTION
## Description

Currently, if an action has type "Skip", the associated tags are not appended to the list of tags. See https://github.com/curiefense/curiefense/issues/1042