### PR TITLE
Update curiefense-manual-build-image.yml

### DIFF
--- a/.github/workflows/curiefense-manual-build-image.yml
+++ b/.github/workflows/curiefense-manual-build-image.yml
@@ -29,4 +29,3 @@ jobs:
             PUSH=1 ./build-docker-images.sh
             export DOCKER_TAG=dev
             PUSH=1 ./build-docker-images.sh
-Symbols


### PR DESCRIPTION
seems to be a rogue line at the end of the file ("symbols"), which to my understanding (together with @yitzchake ) disables the relevant action