### PR TITLE
fix: remove lower prio/higher threshold rate limits

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/config/limit.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/config/limit.rs
@@ -46,7 +46,7 @@ impl Limit {
     fn convert(
         logs: &mut Logs,
         actions: &HashMap<String, SimpleAction>,
-        rawlimit: RawLimit,
+        mut rawlimit: RawLimit,
     ) -> anyhow::Result<(Limit, bool)> {
         let mkey: anyhow::Result<Vec<RequestSelector>> = rawlimit
             .key
@@ -57,18 +57,33 @@ impl Limit {
         let pairwith = RequestSelector::resolve_selector_map(rawlimit.pairwith).ok();
         let mut thresholds: Vec<LimitThreshold> = Vec::new();
         let id = rawlimit.id;
+
+        rawlimit.thresholds.sort_by(|a, b| a.limit.inner.cmp(&b.limit.inner));
+
+        let mut max_priority = 0;
         for thr in rawlimit.thresholds {
             let action = actions.get(&thr.action).cloned().unwrap_or_else(|| {
                 logs.error(|| format!("Could not resolve action {} in limit {}", thr.action, id));
                 SimpleAction::default()
             });
 
-            thresholds.push(LimitThreshold {
-                limit: thr.limit.inner,
-                action,
-            })
+            let action_priority = action.atype.rate_limit_priority();
+            if action_priority >= max_priority {
+                max_priority = action_priority;
+                thresholds.push(LimitThreshold {
+                    limit: thr.limit.inner,
+                    action,
+                })
+            } else {
+                logs.warning(|| {
+                    format!(
+                        "Limit {}: skipping threshold {:?}: lower priority but higher threshold value than other threshold",
+                        id, thr
+                    )
+                });
+            }
         }
-        thresholds.sort_unstable_by(limit_order);
+
         Ok((
             Limit {
                 id,

--- a/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
@@ -430,6 +430,17 @@ impl SimpleActionT {
         }
     }
 
+    pub fn rate_limit_priority(&self) -> u32 {
+        use SimpleActionT::*;
+        match self {
+            Custom { content: _ } => 8,
+            Challenge => 6,
+            Monitor => 1,
+            // skip action should be ignored when using with rate limit
+            Skip => 0,
+        }
+    }
+
     fn is_blocking(&self) -> bool {
         !matches!(self, SimpleActionT::Monitor)
     }

--- a/curiefense/curieproxy/rust/luatests/config/json/limits.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/limits.json
@@ -554,5 +554,61 @@
     "global": false,
     "active": true,
     "timeframe": 3
+  },
+  {
+    "description": "rate limit skip threshold",
+    "exclude": [],
+    "id": "skipthreshold",
+    "include": [],
+    "key": [
+      {
+        "attrs": "ip"
+      }
+    ],
+    "name": "rate limit skip threshold",
+    "pairwith": {
+      "self": "self"
+    },
+    "thresholds": [
+      {
+        "action": "default",
+        "limit": 1
+      },
+      {
+        "action": "monitor",
+        "limit": 2
+      }
+    ],
+    "global": false,
+    "active": true,
+    "timeframe": 60
+  },
+  {
+    "description": "rate limit no skip threshold",
+    "exclude": [],
+    "id": "noskipthreshold",
+    "include": [],
+    "key": [
+      {
+        "attrs": "ip"
+      }
+    ],
+    "name": "rate limit skip threshold",
+    "pairwith": {
+      "self": "self"
+    },
+    "thresholds": [
+      {
+        "action": "monitor",
+        "limit": 1
+      },
+      {
+        "action": "default",
+        "limit": 2
+      }
+    ],
+    "global": false,
+    "active": true,
+    "timeframe": 60
   }
 ]

--- a/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
+++ b/curiefense/curieproxy/rust/luatests/config/json/securitypolicy.json
@@ -531,6 +531,30 @@
                 ]
             },
             {
+                "match": "^/limits/thresholdskip",
+                "name": "skipping threshold",
+                "id": "skipping threshold",
+                "acl_profile": "__default__",
+                "acl_active": true,
+                "content_filter_profile": "__default__",
+                "content_filter_active": false,
+                "limit_ids": [
+                    "skipthreshold"
+                ]
+            },
+            {
+                "match": "^/limits/thresholdnoskip",
+                "name": "no skipping threshold",
+                "id": "no skipping threshold",
+                "acl_profile": "__default__",
+                "acl_active": true,
+                "content_filter_profile": "__default__",
+                "content_filter_active": false,
+                "limit_ids": [
+                    "noskipthreshold"
+                ]
+            },
+            {
                 "match": "^/limits/multilimits",
                 "name": "multiple limits same location",
                 "id": "multiple limits same location",

--- a/curiefense/curieproxy/rust/luatests/ratelimit/test-threshold-priority.json
+++ b/curiefense/curieproxy/rust/luatests/ratelimit/test-threshold-priority.json
@@ -1,0 +1,58 @@
+[
+  {
+    "desc": "Testing skipping thresholds",
+    "headers": {
+      "x-forwarded-for": "25.65.8.125",
+      ":method": "GET",
+      ":path": "/limits/thresholdskip"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "25.65.8.125",
+      ":method": "GET",
+      ":path": "/limits/thresholdskip"
+    },
+    "delay": 0,
+    "pass": false
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "25.65.8.125",
+      ":method": "GET",
+      ":path": "/limits/thresholdskip"
+    },
+    "delay": 0,
+    "pass": false
+  },
+  {
+    "desc": "Testing no skipping thresholds",
+    "headers": {
+      "x-forwarded-for": "25.65.8.125",
+      ":method": "GET",
+      ":path": "/limits/thresholdnoskip"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "25.65.8.125",
+      ":method": "GET",
+      ":path": "/limits/thresholdnoskip"
+    },
+    "delay": 0,
+    "pass": true
+  },
+  {
+    "headers": {
+      "x-forwarded-for": "25.65.8.125",
+      ":method": "GET",
+      ":path": "/limits/thresholdnoskip"
+    },
+    "delay": 0,
+    "pass": false
+  }
+]


### PR DESCRIPTION
## Description

Consider this rate limit rule :

```
threshold = 100, action = block
threshold = 200, action = monitor <-- deleted
```

This PR removes the second threshold as it as lower priority than a smaller threshold.