### PR TITLE
Separate the flow & limit stages

### DIFF
--- a/curiefense/curieproxy/lua/session_nginx.lua
+++ b/curiefense/curieproxy/lua/session_nginx.lua
@@ -107,37 +107,22 @@ function session_rust_nginx.inspect(handle, loglevel, secpolid, plugins)
     if not res.decided then
         -- handle flow / limit
         local flows = res.flows
-        local limits = res.limits
         local rflows = {}
         local rlimits = {}
+        local red = nil
 
         -- TODO: avoid connecting to redis when there are no flows and all limits are zero limits
-        if not rawequal(next(flows), nil) or not rawequal(next(limits), nil) then
+        if not rawequal(next(flows), nil) then
             -- Redis required
-            local red = redis_connect(handle)
+            red = redis_connect(handle)
             red:init_pipeline()
             for _, flow in pairs(flows) do
                 red:llen(flow.key)
-            end
-            for _, limit in pairs(limits) do
-                local key = limit.key
-                if not limit.zero_limits then
-                    local pw = limit.pairwith
-                    if pw then
-                        red:sadd(key, pw)
-                        red:scard(key)
-                        red:ttl(key)
-                    else
-                        red:incr(key)
-                        red:ttl(key)
-                    end
-                end
             end
             local results, redis_err = red:commit_pipeline()
             if redis_err or not results then
                 handle.log(handle.ERR, "failed to run redis calls: " .. redis_err)
                 flows = {}
-                limits = {}
             end
 
             local result_idx = 1
@@ -165,6 +150,38 @@ function session_rust_nginx.inspect(handle, loglevel, secpolid, plugins)
                 end
                 table.insert(rflows, flow:result(flowtype))
             end
+        end
+
+        local r2 = curiefense.inspect_request_flows(res, rflows)
+        local limits = r2.limits
+
+        if not rawequal(next(limits), nil) then
+            if red == nil then
+                red = redis_connect(handle)
+            end
+            red:init_pipeline()
+
+            for _, limit in pairs(limits) do
+                local key = limit.key
+                if not limit.zero_limits then
+                    local pw = limit.pairwith
+                    if pw then
+                        red:sadd(key, pw)
+                        red:scard(key)
+                        red:ttl(key)
+                    else
+                        red:incr(key)
+                        red:ttl(key)
+                    end
+                end
+            end
+            local results, redis_err = red:commit_pipeline()
+            if redis_err or not results then
+                handle.log(handle.ERR, "failed to run redis calls: " .. redis_err)
+                limits = {}
+            end
+
+            local result_idx = 1
 
             red:init_pipeline()
             for _, limit in pairs(limits) do
@@ -193,7 +210,7 @@ function session_rust_nginx.inspect(handle, loglevel, secpolid, plugins)
             red:set_keepalive(300000, 360)
         end
 
-        res = curiefense.inspect_request_process(res, rflows, rlimits)
+        res = curiefense.inspect_request_process(r2, rlimits)
         if res.error then
             handle.log(handle.ERR, sfmt("curiefense.inspect_request_process error %s", res.error))
         end

--- a/curiefense/curieproxy/rust/curiefense/src/incremental.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/incremental.rs
@@ -235,7 +235,7 @@ pub async fn finalize<GH: Grasshopper>(
         .unwrap_or(CfRulesArg::Global);
     let reqinfo = map_request(
         &mut logs,
-        secpolicy,
+        secpolicy.clone(),
         idata.container_name,
         &rawrequest,
         Some(idata.start),

--- a/curiefense/curieproxy/rust/curiefense/src/interface/stats.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/stats.rs
@@ -51,7 +51,9 @@ pub struct BStageInit;
 pub struct BStageSecpol;
 #[derive(Clone)]
 pub struct BStageMapped;
+#[derive(Clone)]
 pub struct BStageFlow;
+#[derive(Clone)]
 pub struct BStageLimit;
 pub struct BStageAcl;
 pub struct BStageContentFilter;

--- a/curiefense/curieproxy/rust/luatests/test.lua
+++ b/curiefense/curieproxy/rust/luatests/test.lua
@@ -133,6 +133,7 @@ local function run_inspect_request_gen(raw_request_map, mode)
         res = curiefense.inspect_request({loglevel="debug", meta=meta, headers=headers,
                 body=raw_request_map.body, ip=ip, plugins=raw_request_map.plugins})
       else
+        -- APhase1
         local r1 = curiefense.inspect_request_init({loglevel="debug", meta=meta,
                     headers=headers, body=raw_request_map.body, ip=ip,
                     plugins=raw_request_map.plugins})
@@ -170,7 +171,10 @@ local function run_inspect_request_gen(raw_request_map, mode)
           table.insert(rflows, flow:result(flowtype))
         end
 
-        local limits = r1.limits
+        -- APhase2I
+        local r2 = curiefense.inspect_request_flows(r1, rflows)
+
+        local limits = r2.limits
         local rlimits = {}
         for _, limit in pairs(limits) do
           local key = limit.key
@@ -196,7 +200,7 @@ local function run_inspect_request_gen(raw_request_map, mode)
           table.insert(rlimits, limit:result(curcount))
         end
 
-        res = curiefense.inspect_request_process(r1, rflows, rlimits)
+        res = curiefense.inspect_request_process(r2, rlimits)
       end
     end
     if res.error then


### PR DESCRIPTION
This should fix #1121.

It separates the flow stage from the limit stage, so that limits can see the tags set during the flow stage.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>