### PR TITLE
Bump istio to 1.16.1

### DIFF
--- a/curiefense/images/curieproxy-istio/Dockerfile
+++ b/curiefense/images/curieproxy-istio/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUSTBIN_TAG=latest
 FROM curiefense/curiefense-rustbuild-focal:${RUSTBIN_TAG} AS rustbin
-FROM docker.io/istio/proxyv2:1.15.2
+FROM docker.io/istio/proxyv2:1.16.1
 
 RUN apt-get update && \
     apt-get -yq --no-install-recommends install jq luarocks libpcre2-dev \


### PR DESCRIPTION
Update istio to 1.16.1.

Must be merged before the [corresponding PR in curiefense-helm](https://github.com/curiefense/curiefense-helm/pull/33).

Signed-off-by: Xavier <xavier@reblaze.com>