### PR TITLE
Reduce the log level of action logging to DEBUG

### DIFF
--- a/curiefense/curieproxy/lua/session_nginx.lua
+++ b/curiefense/curieproxy/lua/session_nginx.lua
@@ -36,7 +36,7 @@ local function custom_response(handle, action_params)
         handle.status = status
     end
 
-    handle.log(handle.ERR, cjson.encode(action_params))
+    handle.log(handle.DEBUG, cjson.encode(action_params))
 
     if block_mode then
         if action_params["content"] then handle.say(action_params["content"]) end


### PR DESCRIPTION
ERROR is way too high for what is basically a debug message.

Signed-off-by: Simon Marechal <bartavelle@gmail.com>