### PR TITLE
Improve CI logging

### DIFF
--- a/.github/workflows/e2e-minikube-filebeat.yml
+++ b/.github/workflows/e2e-minikube-filebeat.yml
@@ -69,15 +69,15 @@ jobs:
             kubectl -n istio-system describe pods
             kubectl -n curiefense describe pods
             echo "--- Logs for istio ingressgateway ---"
-            kubectl -n istio-system logs --all-containers -l app=istio-ingressgateway --tail -1 --prefix -p --timestamps
+            kubectl -n istio-system logs --all-containers -l app=istio-ingressgateway --tail -1 --prefix --timestamps
             echo "--- Logs for istiod ---"
-            kubectl -n istio-system logs --all-containers -l app=istiod --tail -1 --prefix -p --timestamps
+            kubectl -n istio-system logs --all-containers -l app=istiod --tail -1 --prefix --timestamps
             echo "--- Logs for confserver ---"
-            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=confserver --tail -1 --prefix -p --timestamps
+            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=confserver --tail -1 --prefix --timestamps
             echo "--- Logs for redis ---"
-            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=redis --tail -1 --prefix -p --timestamps
+            kubectl -n curiefense logs --all-containers -l app.kubernetes.io/name=redis --tail -1 --prefix --timestamps
             echo "--- Logs for echoserver ---"
-            kubectl -n echoserver logs --all-containers -l app=echoserver --tail -1 --prefix -p --timestamps
+            kubectl -n echoserver logs --all-containers -l app=echoserver --tail -1 --prefix --timestamps
 
 
       - name: Publish Unit Test Results


### PR DESCRIPTION
Remove `-p` parameter, which fails when a previous container is no longer available.
With this change, the reason why the k8s tests are broken since [this merge commit](https://github.com/curiefense/curiefense/commit/e8773a109e5641c856d946498bf51a47da6d9407) is visible:
```
E 1780µs When loading manifest.json: No such file or directory (os error 2)
```
