### PR TITLE
Support ssh key for git operations in confserver

### DIFF
--- a/curiefense/images/confserver/bootstrap/bootstrap_config.sh
+++ b/curiefense/images/confserver/bootstrap/bootstrap_config.sh
@@ -13,6 +13,9 @@ fi
 echo "Config directory $TARGETDIR is empty"
 
 if [ -n "$IF_NO_CONFIG_PULL_FROM" ]; then
+	if [ -n "$CURIECONF_GIT_SSH_KEY_PATH" ]; then
+		export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i $CURIECONF_GIT_SSH_KEY_PATH"
+	fi
 	echo "Cloning configuration from $IF_NO_CONFIG_PULL_FROM"
 	git clone --mirror "$IF_NO_CONFIG_PULL_FROM" "$TARGETDIR"
 	exit 0


### PR DESCRIPTION
The `gitpush` and `gitfetch` APIs can now used a private SSH key if its path is passed in the `CURIECONF_GIT_SSH_KEY_PATH` environment variable

`gitfetch` now updates local branch references.

Do not merge unless CI is fully green. This will require fixing curieproxy on `main` first.