### PR TITLE
Ipinfo fixes

### DIFF
--- a/curiefense/curieconf/client/curieconf/cli/__init__.py
+++ b/curiefense/curieconf/client/curieconf/cli/__init__.py
@@ -495,21 +495,26 @@ def pullipinfo(project: str, bucket: str, ipinfo_dir: str, target_path: str):
 
     os.makedirs(target_path, exist_ok=True)
 
-
     for ipinfo_blob in [*(client.list_blobs(bucket_or_name=bucket, prefix=ipinfo_dir))]:
         remote_md5 = base64.b64decode(ipinfo_blob.md5_hash).hex()
         file_name = ipinfo_blob.name.split("/")[-1]
         if not os.path.isfile(target_path + file_name):
             try:
                 ipinfo_blob.download_to_filename(target_path + file_name)
-                with open(target_path+file_name.split(".")[0]+"_hash", "w") as hash_file:
+                with open(
+                    target_path + file_name.split(".")[0] + "_hash", "w"
+                ) as hash_file:
                     hash_file.write(remote_md5)
             except Exception as ex:
-                typer.echo(f"failed downloading {file_name} - {ex}", )
+                typer.echo(
+                    f"failed downloading {file_name} - {ex}",
+                )
                 continue
             typer.echo(f"downloaded {file_name} to {target_path}")
         else:
-            with open(target_path+file_name.split(".")[0]+"_hash", "r+") as hash_file:
+            with open(
+                target_path + file_name.split(".")[0] + "_hash", "r+"
+            ) as hash_file:
 
                 remote_md5 = base64.b64decode(ipinfo_blob.md5_hash).hex()
                 local_md5 = hash_file.readline().rstrip()
@@ -524,8 +529,9 @@ def pullipinfo(project: str, bucket: str, ipinfo_dir: str, target_path: str):
                         continue
 
                 else:
-                    typer.echo(f"{target_path} already contains the updated {file_name}")
-
+                    typer.echo(
+                        f"{target_path} already contains the updated {file_name}"
+                    )
 
 
 @sync.command()

--- a/curiefense/curieconf/client/curieconf/cli/__init__.py
+++ b/curiefense/curieconf/client/curieconf/cli/__init__.py
@@ -495,6 +495,7 @@ def pullipinfo(project: str, bucket: str, ipinfo_dir: str, target_path: str):
 
     os.makedirs(target_path, exist_ok=True)
 
+
     for ipinfo_blob in [*(client.list_blobs(bucket_or_name=bucket, prefix=ipinfo_dir))]:
         remote_md5 = base64.b64decode(ipinfo_blob.md5_hash).hex()
         file_name = ipinfo_blob.name.split("/")[-1]
@@ -664,5 +665,4 @@ def main():
 
 
 if __name__ == "__main__":
-    #main()
-    pullipinfo("rbz-internal", "rbz-dev-auto-acl", "ipinfo", "/tmp/ipinfo/")
+    main()

--- a/curiefense/curieconf/client/curieconf/cli/__init__.py
+++ b/curiefense/curieconf/client/curieconf/cli/__init__.py
@@ -502,9 +502,7 @@ def pullipinfo(project: str, bucket: str, ipinfo_dir: str, target_path: str):
         if not os.path.isfile(target_path + file_name):
             try:
                 ipinfo_blob.download_to_filename(target_path + file_name)
-                with open(
-                        hash_file_name, "w"
-                ) as hash_file:
+                with open(hash_file_name, "w") as hash_file:
                     hash_file.write(remote_md5)
             except Exception as ex:
                 typer.echo(f"failed downloading {file_name} - {ex}", err=True)

--- a/curiefense/curieconf/client/curieconf/cli/__init__.py
+++ b/curiefense/curieconf/client/curieconf/cli/__init__.py
@@ -9,6 +9,7 @@ import io
 import json
 import subprocess
 from enum import Enum
+from pathlib import Path
 from google.cloud import storage
 import base64
 from typing import List, Optional
@@ -497,8 +498,9 @@ def pullipinfo(project: str, bucket: str, ipinfo_dir: str, target_path: str):
 
     for ipinfo_blob in [*(client.list_blobs(bucket_or_name=bucket, prefix=ipinfo_dir))]:
         remote_md5 = base64.b64decode(ipinfo_blob.md5_hash).hex()
-        file_name = ipinfo_blob.name.split("/")[-1]
-        hash_file_name = target_path + file_name.split(".")[0] + "_hash"
+        path = Path(ipinfo_blob.name)
+        file_name = path.name
+        hash_file_name = target_path + path.stem + "_hash"
         if not os.path.isfile(target_path + file_name):
             try:
                 ipinfo_blob.download_to_filename(target_path + file_name)

--- a/curiefense/curieconf/client/curieconf/cli/__init__.py
+++ b/curiefense/curieconf/client/curieconf/cli/__init__.py
@@ -515,7 +515,6 @@ def pullipinfo(project: str, bucket: str, ipinfo_dir: str, target_path: str):
             with open(
                 target_path + file_name.split(".")[0] + "_hash", "r+"
             ) as hash_file:
-
                 remote_md5 = base64.b64decode(ipinfo_blob.md5_hash).hex()
                 local_md5 = hash_file.readline().rstrip()
                 if not local_md5 == remote_md5:

--- a/curiefense/images/curiesync/init/pull.sh
+++ b/curiefense/images/curiesync/init/pull.sh
@@ -22,7 +22,7 @@ if [ "$RUN_MODE" = "SYNC_ONCE" ]; then
     curieconfctl sync pull "${CURIE_BUCKET_LINK}" /cf-config
     if [ "$USE_IPINFO" = "true" ]
     then
-      curieconfctl sync pullipinfo rbz-internal rbz-dev-auto-acl ipinfo /cf-config/ipinfo/
+      curieconfctl sync pullipinfo "${IPINFO_PROJECT}" "${IPINFO_REMOTE_BUCKET}" "${IPINFO_REMOTE_DIR}" /cf-config/ipinfo/
     fi
     exit 0
 fi
@@ -54,7 +54,7 @@ if [ "$RUN_MODE" = "PERIODIC_SYNC" ] || [ -z "$RUN_MODE" ]; then
         curieconfctl sync pull "${CURIE_BUCKET_LINK}" /cf-config --on-conf-change "$CONFIGCHANGE"
         if [ "$USE_IPINFO" = "true" ]
         then
-          curieconfctl sync pullipinfo rbz-internal rbz-dev-auto-acl ipinfo /cf-config/ipinfo/
+          curieconfctl sync pullipinfo "${IPINFO_PROJECT}" "${IPINFO_REMOTE_BUCKET}" "${IPINFO_REMOTE_DIR}" /cf-config/ipinfo/
         fi
         info "Sleeping"
         sleep $PERIOD

--- a/curiefense/images/curiesync/init/pull.sh
+++ b/curiefense/images/curiesync/init/pull.sh
@@ -20,8 +20,10 @@ fi
 if [ "$RUN_MODE" = "SYNC_ONCE" ]; then
     info "Synchronizing once"
     curieconfctl sync pull "${CURIE_BUCKET_LINK}" /cf-config
-    curieconfctl sync pullipinfo rbz-internal rbz-dev-auto-acl ipinfo /cf-config/ipinfo/
-
+    if [ "$USE_IPINFO" = "true" ]
+    then
+      curieconfctl sync pullipinfo rbz-internal rbz-dev-auto-acl ipinfo /cf-config/ipinfo/
+    fi
     exit 0
 fi
 
@@ -49,8 +51,11 @@ if [ "$RUN_MODE" = "PERIODIC_SYNC" ] || [ -z "$RUN_MODE" ]; then
     while :;
     do
         info "Pulling ${CURIE_BUCKET_LINK}"
-        curieconfctl sync pullipinfo rbz-internal rbz-dev-auto-acl ipinfo /cf-config/ipinfo/
         curieconfctl sync pull "${CURIE_BUCKET_LINK}" /cf-config --on-conf-change "$CONFIGCHANGE"
+        if [ "$USE_IPINFO" = "true" ]
+        then
+          curieconfctl sync pullipinfo rbz-internal rbz-dev-auto-acl ipinfo /cf-config/ipinfo/
+        fi
         info "Sleeping"
         sleep $PERIOD
     done


### PR DESCRIPTION
additions -

- ipinfo is pulled only if the USE_IPINFO is set to true
- use of environment variables to determine the bucket to pull the ipinfo files from.
- to avoid pulling process from being killed - instead of reading the local files to get their md5s (large files, requiring many resources), the current md5 is being saved in an additional file, and updated when needed.

<img width="809" alt="image" src="https://user-images.githubusercontent.com/92663724/222384118-a41bfc0f-d291-4716-b007-980ad698d024.png">
