### PR TITLE
Add python-related pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,23 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 21.7b0
-    hooks:
-    -   id: black
-        args: ["--check", "--diff"]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-added-large-files
+- repo: https://github.com/psf/black
+  rev: "22.6.0"
+  hooks:
+  - id: black
+    args: ["--check", "--diff"]
+- repo: https://github.com/pycqa/flake8
+  rev: "5.0.4"
+  hooks:
+  - id: flake8
+    exclude: docs/
+- repo: https://github.com/pycqa/isort
+  rev: "5.11.5"
+  hooks:
+  - id: isort
+    exclude: docs/

--- a/curiefense/curieconf/client/curieconf/cli/__init__.py
+++ b/curiefense/curieconf/client/curieconf/cli/__init__.py
@@ -1,30 +1,25 @@
 #! /usr/bin/env python
-import hashlib
-import logging
-import os
-import sys
 import argparse
-import traceback
+import base64
+import hashlib
 import io
 import json
+import logging
+import os
 import subprocess
+import sys
+import traceback
 from enum import Enum
 from pathlib import Path
-from google.cloud import storage
-import base64
 from typing import List, Optional
 
-
+import simple_rest_client.exceptions
 import typer
 import yaml
-
-import simple_rest_client.exceptions
-
-
-from curieconf import confclient
-from curieconf import utils
+from cloudstorage.exceptions import CloudStorageError, NotFoundError
+from curieconf import confclient, utils
 from curieconf.utils import cloud
-from cloudstorage.exceptions import NotFoundError, CloudStorageError
+from google.cloud import storage
 
 state = argparse.Namespace()
 


### PR DESCRIPTION
### Description

* Add pre-commit hook for [isort](https://pycqa.github.io/isort/)
* Add pre-commit hook for [flake8](https://flake8.pycqa.org/en/latest/)
* Update black pre-commit hook to `22.6.0` version

### Changes
* `curiefense/curieconf/client/curieconf/cli/__init__.py` imports are formatted with isort