### PR TITLE
Fix initial loading for the custom configuration

### DIFF
--- a/.github/workflows/curiefense-manual-build-image.yml
+++ b/.github/workflows/curiefense-manual-build-image.yml
@@ -9,7 +9,8 @@ jobs:
 
     environment: prod
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -17,15 +18,14 @@ jobs:
         run: |
             docker login -u "${{ secrets.DOCKER_HUB_USER }}" -p "${{ secrets.DOCKER_HUB_PASSWORD }}"
             pushd curiefense/images
-            export DOCKER_TAG=$(echo ${GITHUB_REF#refs/heads/})
+            export DOCKER_TAG=$(echo ${GITHUB_REF_NAME#//\//-})
             PUSH=1 ./build-docker-images.sh
             export DOCKER_TAG=${GITHUB_SHA}
             PUSH=1 ./build-docker-images.sh
-      - name: add 'dev' tag
+
+      - name: Add 'dev' tag
         run: |
             docker login -u "${{ secrets.DOCKER_HUB_USER }}" -p "${{ secrets.DOCKER_HUB_PASSWORD }}"
             pushd curiefense/images
-            export DOCKER_TAG=dev
-            PUSH=1 ./build-docker-images.sh
             export DOCKER_TAG=dev
             PUSH=1 ./build-docker-images.sh

--- a/.github/workflows/curiefense-manual-build-image.yml
+++ b/.github/workflows/curiefense-manual-build-image.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
             docker login -u "${{ secrets.DOCKER_HUB_USER }}" -p "${{ secrets.DOCKER_HUB_PASSWORD }}"
             pushd curiefense/images
-            export DOCKER_TAG=$(echo ${GITHUB_REF_NAME#//\//-})
+            export DOCKER_TAG=${GITHUB_REF_NAME//\//-}
             PUSH=1 ./build-docker-images.sh
             export DOCKER_TAG=${GITHUB_SHA}
             PUSH=1 ./build-docker-images.sh

--- a/curiefense/images/curieproxy-nginx/nginx-conf-watch.sh
+++ b/curiefense/images/curieproxy-nginx/nginx-conf-watch.sh
@@ -12,22 +12,15 @@ fi
 # The file that we are going to monitor
 confarchive=/cf-config/current/config/customconf.tar.gz
 
-# Store the initial md5sum of the file
-if [ -f "$confarchive" ]; then
-    # If the file exists, calculate its md5sum
-    original_md5=$(md5sum "$confarchive" | awk '{print $1}')
-else
-    # If the file does not exist, store an empty string
-    original_md5=""
-fi
+# Hashsum for the config file, empty to invoke initial loading
+original_md5=""
 
-while true
-do
+while true; do
 if [ -f "$confarchive" ]; then
     # Compare the current md5sum with the original
     current_md5=$(md5sum "$confarchive" | awk '{print $1}')
     if [ "$current_md5" != "$original_md5" ]; then
-        echo "watch-customconf: New copy of $confarchive found. calling reload script."
+        echo "watch-customconf: New copy of $confarchive found, reloading..."
         # If the md5sums are different, it means that the file has been modified, so call the reload script
         /usr/local/bin/nginx-conf-reload.sh &
         # Update the original md5sum
@@ -35,7 +28,7 @@ if [ -f "$confarchive" ]; then
     fi
     sleep 10; # Sleep for 10 seconds before checking the file again
 else
-    echo "watch-customconf: ${confarchive} missing" >&2
+    echo "watch-customconf: ${confarchive} is missing" >&2
     sleep 1; # Sleep for 1 second before checking the file again
 fi
 done


### PR DESCRIPTION
### Description
Reload nginx configuration when file is created and on any further file updates / recreation too (in case content differs).

Approach with `inotifywait` was tried, but it doesn't cover initial creation case.
inotify is an efficient way to monitor events on the files (and `inotify-tools` is a C-based interface for that https://github.com/inotify-tools/inotify-tools/wiki). md5 calculation is more expensive call, so this should be an optimization for this watcher script

### Testing
`NGINX_CONFIGURATION_TEMPLATE=no` env variable is set

* Testing initial creation of the file
```console
$ docker run --env-file .docker.env --rm --name proxytst curieproxy-nginx

$ docker exec -it proxytst bash
$ mkdir -p /cf-config/current/config/
$ cd /cf-config/current/config/
$ echo "# custom config" >> foo.bar
$ tar -czvf customconf.tar.gz foo.bar
```
![Screenshot 2023-04-03 at 2 47 02 PM](https://user-images.githubusercontent.com/3602533/229513958-0e77d84d-505a-48aa-a3bc-14c06a7703ee.png)

* Testing updating of the existing file
```console
$ docker run --env-file .docker.env --rm --name proxytst -v `pwd`/customconf.tar.gz:/cf-config/current/config/customconf.tar.gz curieproxy-nginx

$ docker exec -it proxytst bash
$  cd /cf-config/current/config/
$  echo "# updated config" >> foo.bar
$ tar -czvf customconf.tar.gz foo.bar
```
![Screenshot 2023-04-03 at 2 51 01 PM](https://user-images.githubusercontent.com/3602533/229515177-95a89946-3b17-4f31-a5d0-1cf184bcd0a6.png)
(both initial config loading and reload after update took place)