### PR TITLE
RR-2990 - Fixed adding the global filters block reasons (displayed as…

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/analyze.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/analyze.rs
@@ -171,6 +171,13 @@ pub fn analyze_init<GH: Grasshopper>(logs: &mut Logs, mgh: Option<&GH>, p0: APha
         }
     }
 
+    //early extraction of the global filters block reasons, to be added to the special url requests' 'triggers' as well:
+    let gf_reasons = if let SimpleDecision::Action(_action, reason) = &globalfilter_dec {
+        reason.to_owned()
+    } else {
+        vec![]
+    };
+
     //if /7060 then call gh phase02
     if reqinfo
         .rinfo
@@ -179,7 +186,7 @@ pub fn analyze_init<GH: Grasshopper>(logs: &mut Logs, mgh: Option<&GH>, p0: APha
         .starts_with("/7060ac19f50208cbb6b45328ef94140a612ee92387e015594234077b4d1e64f1")
     {
         logs.debug("Call challenge phase02");
-        if let Some(decision) = mgh.and_then(|gh| challenge_phase02(gh, logs, &reqinfo)) {
+        if let Some(decision) = mgh.and_then(|gh| challenge_phase02(gh, logs, &reqinfo, gf_reasons.clone())) {
             return InitResult::Res(AnalyzeResult {
                 decision,
                 tags,
@@ -196,7 +203,7 @@ pub fn analyze_init<GH: Grasshopper>(logs: &mut Logs, mgh: Option<&GH>, p0: APha
         .uri
         .starts_with("/74d8-ffc3-0f63-4b3c-c5c9-5699-6d5b-3a1")
     {
-        if let Some(decision) = mgh.and_then(|gh| check_app_sig(gh, logs, &reqinfo)) {
+        if let Some(decision) = mgh.and_then(|gh| check_app_sig(gh, logs, &reqinfo, gf_reasons.clone())) {
             return InitResult::Res(AnalyzeResult {
                 decision,
                 tags,
@@ -207,14 +214,15 @@ pub fn analyze_init<GH: Grasshopper>(logs: &mut Logs, mgh: Option<&GH>, p0: APha
         logs.debug("check_app_sig ignored");
     }
 
-    //todo handle /8d47?
     if reqinfo
         .rinfo
         .qinfo
         .uri
         .starts_with("/8d47-ffc3-0f63-4b3c-c5c9-5699-6d5b-3a1f")
     {
-        if let Some(decision) = mgh.and_then(|gh| handle_bio_reports(gh, logs, &reqinfo, precision_level)) {
+        if let Some(decision) =
+            mgh.and_then(|gh| handle_bio_reports(gh, logs, &reqinfo, precision_level, gf_reasons.clone()))
+        {
             return InitResult::Res(AnalyzeResult {
                 decision,
                 tags,

--- a/curiefense/curieproxy/rust/curiefense/src/grasshopper.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/grasshopper.rs
@@ -280,7 +280,12 @@ pub fn challenge_phase01<GH: Grasshopper>(
     )
 }
 
-pub fn challenge_phase02<GH: Grasshopper>(gh: &GH, logs: &mut Logs, reqinfo: &RequestInfo) -> Option<Decision> {
+pub fn challenge_phase02<GH: Grasshopper>(
+    gh: &GH,
+    logs: &mut Logs,
+    reqinfo: &RequestInfo,
+    reasons: Vec<BlockReason>,
+) -> Option<Decision> {
     if !reqinfo
         .rinfo
         .qinfo
@@ -317,11 +322,16 @@ pub fn challenge_phase02<GH: Grasshopper>(gh: &GH, logs: &mut Logs, reqinfo: &Re
             content: "{}".to_string(),
             extra_tags: Some(["challenge_phase02"].iter().map(|s| s.to_string()).collect()),
         },
-        vec![],
+        reasons,
     ))
 }
 
-pub fn check_app_sig<GH: Grasshopper>(gh: &GH, logs: &mut Logs, reqinfo: &RequestInfo) -> Option<Decision> {
+pub fn check_app_sig<GH: Grasshopper>(
+    gh: &GH,
+    logs: &mut Logs,
+    reqinfo: &RequestInfo,
+    reasons: Vec<BlockReason>,
+) -> Option<Decision> {
     if !reqinfo
         .rinfo
         .qinfo
@@ -347,7 +357,7 @@ pub fn check_app_sig<GH: Grasshopper>(gh: &GH, logs: &mut Logs, reqinfo: &Reques
             content: "{}".to_string(),
             extra_tags: Some(["check_app_sig"].iter().map(|s| s.to_string()).collect()),
         },
-        vec![],
+        reasons,
     ))
 }
 
@@ -356,6 +366,7 @@ pub fn handle_bio_reports<GH: Grasshopper>(
     logs: &mut Logs,
     reqinfo: &RequestInfo,
     precision_level: PrecisionLevel,
+    reasons: Vec<BlockReason>,
 ) -> Option<Decision> {
     if !reqinfo
         .rinfo
@@ -389,6 +400,6 @@ pub fn handle_bio_reports<GH: Grasshopper>(
             content: gh_response.str_response,
             extra_tags: Some(["handle_bio_reports"].iter().map(|s| s.to_string()).collect()),
         },
-        vec![],
+        reasons,
     ))
 }


### PR DESCRIPTION
… 'triggers' in the logs) for the internal challenge requests as well (/7060 and /8d47)