### PR TITLE
Use Python 3.11 for e2e tests

### DIFF
--- a/.github/workflows/e2e-compose-tests.yml
+++ b/.github/workflows/e2e-compose-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
 
     steps:
       - name: Checkout

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,4 +1,5 @@
 pytest ~= 7.1
 requests ~= 2.28
-requests-toolbelt ~= 0.9.1
+requests-toolbelt ~= 0.10.1
+urllib3 ~=1.26.15
 wheel ~= 0.37


### PR DESCRIPTION
E2E tests failing because of an updated dependency:
- https://github.com/curiefense/curiefense/actions/runs/4945253012/jobs/8841712865 

Solution described here:
- https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli

Solution successfully implemented here:
- https://github.com/curiefense/curiefense/actions/runs/4946259559

Update e2e python version.
Update requests-toolbelt ~= 0.10.1
Add urllib3 ~=1.26.15