### PR TITLE
Logs schema updates (RR-3127, RR-3116, RR-3130)

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
@@ -524,7 +524,6 @@ pub fn jsonlog_rinfo(
         map_ser.serialize_entry("blocked", &blocked)?;
     }
 
-
     struct EmptyMap;
     impl Serialize for EmptyMap {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
@@ -276,7 +276,7 @@ pub fn jsonlog_rinfo(
 
     map_ser.serialize_entry("geo_region", &rinfo.rinfo.geoip.region)?;
     map_ser.serialize_entry("geo_country", &rinfo.rinfo.geoip.country_name)?;
-    map_ser.serialize_entry("geo-org", &rinfo.rinfo.geoip.company)?;
+    map_ser.serialize_entry("geo_org", &rinfo.rinfo.geoip.company)?;
 
     //pulled up from tags
     let mut has_monitor = false;

--- a/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
@@ -8,10 +8,10 @@ use crate::utils::json::NameValue;
 use crate::utils::templating::{parse_request_template, RequestTemplate, TVar, TemplatePart};
 use crate::utils::{selector, GeoIp, RequestInfo, Selected};
 use chrono::{DateTime, Duration, DurationRound};
+use md5;
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
-use md5;
 
 pub use self::block_reasons::*;
 pub use self::stats::*;

--- a/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
@@ -537,7 +537,7 @@ pub fn jsonlog_rinfo(
     }
     map_ser.serialize_entry("profiling", &stats.timing)?;
 
-    map_ser.serialize_entry("rbz_latency", &stats.timing.sum_fields())?;
+    map_ser.serialize_entry("rbz_latency", &stats.timing.max_value())?;
 
     SerializeMap::end(map_ser)?;
     Ok(outbuffer)

--- a/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/mod.rs
@@ -512,15 +512,18 @@ pub fn jsonlog_rinfo(
     }
     map_ser.serialize_entry("trigger_counters", &TriggerCounters(&greasons))?;
 
-    //blocked
-    let mut blocked = false;
-    for r in &dec.reasons {
-        if !(matches!(r.action, RawActionType::Monitor) || matches!(r.action, RawActionType::Skip)) {
-            blocked = true;
-            break;
+    //blocked (only if doesn't have challenge, because it'll be counted differently)
+    if !(has_challenge || has_ichallenge) {
+        let mut blocked = false;
+        for r in &dec.reasons {
+            if !(matches!(r.action, RawActionType::Monitor) || matches!(r.action, RawActionType::Skip)) {
+                blocked = true;
+                break;
+            }
         }
+        map_ser.serialize_entry("blocked", &blocked)?;
     }
-    map_ser.serialize_entry("blocked", &blocked)?;
+
 
     struct EmptyMap;
     impl Serialize for EmptyMap {

--- a/curiefense/curieproxy/rust/curiefense/src/interface/stats.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/stats.rs
@@ -48,27 +48,27 @@ impl Serialize for TimingInfo {
 }
 
 impl TimingInfo {
-    pub fn sum_fields(&self) -> u64 {
-        let mut sum = 0;
+    pub fn max_value(&self) -> u64 {
+        let mut max_value: u64 = 0;
         if let Some(value) = self.secpol {
-            sum += value;
+            max_value = value.max(max_value);
         }
         if let Some(value) = self.mapping {
-            sum += value;
+            max_value = value.max(max_value);
         }
         if let Some(value) = self.flow {
-            sum += value;
+            max_value = value.max(max_value);
         }
         if let Some(value) = self.limit {
-            sum += value;
+            max_value = value.max(max_value);
         }
         if let Some(value) = self.acl {
-            sum += value;
+            max_value = value.max(max_value);
         }
         if let Some(value) = self.content_filter {
-            sum += value;
+            max_value = value.max(max_value);
         }
-        sum
+        max_value
     }
 }
 

--- a/curiefense/curieproxy/rust/curiefense/src/interface/stats.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/interface/stats.rs
@@ -47,6 +47,31 @@ impl Serialize for TimingInfo {
     }
 }
 
+impl TimingInfo {
+    pub fn sum_fields(&self) -> u64 {
+        let mut sum = 0;
+        if let Some(value) = self.secpol {
+            sum += value;
+        }
+        if let Some(value) = self.mapping {
+            sum += value;
+        }
+        if let Some(value) = self.flow {
+            sum += value;
+        }
+        if let Some(value) = self.limit {
+            sum += value;
+        }
+        if let Some(value) = self.acl {
+            sum += value;
+        }
+        if let Some(value) = self.content_filter {
+            sum += value;
+        }
+        sum
+    }
+}
+
 pub struct BStageInit;
 pub struct BStageSecpol;
 #[derive(Clone)]


### PR DESCRIPTION
- RR-3127- Add a value in 'blocked' column only if the request doesn't have challenge.
- Get original geo fields,
- Hash rbzid with md5,
- V5GA-282 - Add rbz_latency to be the max value of all the stats(profiling) timing