### PR TITLE
Add cf injection profiling

### DIFF
--- a/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
@@ -142,7 +142,7 @@ pub fn content_filter_check(
                 blocking: true,
                 reasons: iblock.clone(),
             }),
-            stats.cf_matches(total_rules, iblock.len(), total_rules)
+            stats.cf_matches(total_rules, iblock.len(), total_rules),
         );
     }
 

--- a/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
@@ -142,7 +142,7 @@ pub fn content_filter_check(
                 blocking: true,
                 reasons: iblock.clone(),
             }),
-            stats.cf_matches(total_rules, iblock.len(), total_rules),
+            stats.cf_matches(total_rules, iblock.len(), total_rules)
         );
     }
 

--- a/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
@@ -140,7 +140,7 @@ pub fn content_filter_check(
         return (
             Err(CfBlock {
                 blocking: true,
-                reasons: iblock,
+                reasons: iblock.clone(),
             }),
             stats.cf_matches(total_rules, iblock.len(), total_rules),
         );

--- a/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
@@ -136,12 +136,13 @@ pub fn content_filter_check(
         )
     };
     if is_blocking(&iblock) {
+        let total_rules = LIBINJECTION_SQLI_TAGS.len() + LIBINJECTION_XSS_TAGS.len();
         return (
             Err(CfBlock {
                 blocking: true,
                 reasons: iblock,
             }),
-            stats.no_content_filter(),
+            stats.cf_matches(total_rules, iblock.len(), total_rules),
         );
     }
 

--- a/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
+++ b/curiefense/curieproxy/rust/curiefense/src/contentfilter.rs
@@ -36,7 +36,6 @@ lazy_static! {
     pub static ref LIBINJECTION_RULES_LEN: usize = LIBINJECTION_SQLI_TAGS.len() + LIBINJECTION_XSS_TAGS.len();
 }
 
-
 #[derive(Default)]
 struct Omitted {
     entries: Section<HashSet<String>>,
@@ -433,8 +432,8 @@ fn hyperscan(
                 stats.cf_matches(
                     sigs.ids.len() + *LIBINJECTION_RULES_LEN,
                     matches,
-                    nactive + *LIBINJECTION_RULES_LEN
-                )
+                    nactive + *LIBINJECTION_RULES_LEN,
+                ),
             );
         }
     }
@@ -457,7 +456,7 @@ fn hyperscan(
         stats.cf_matches(
             sigs.ids.len() + *LIBINJECTION_RULES_LEN,
             matches,
-            nactive + *LIBINJECTION_RULES_LEN
+            nactive + *LIBINJECTION_RULES_LEN,
         ),
     )
 }


### PR DESCRIPTION
This is the fix for the issue:

When request is blocked by libinjection, the processing time is null. 
(When request  is blocked by signature, can see processing time).

This can influence on latency(rbz_time) calculation. 
Steps to reproduce:
- Send request with argument ‘arg=”--’
- Send request with argument ‘b=<script>alert()</script>’
- Both requests are blocked by Content filter profile
- Open BQ to see the profiling fields for processing time